### PR TITLE
[bug-fix] [admin-menu] Wrapped upgrade menu in a conditional to check for paid plans - fixes #4

### DIFF
--- a/freemius/includes/class-freemius.php
+++ b/freemius/includes/class-freemius.php
@@ -4646,18 +4646,20 @@
 					}
 
 					// Add upgrade/pricing page.
-					$this->add_submenu_item(
-						( $this->is_paying() ? __fs( 'pricing' ) : __fs( 'upgrade' ) . '&nbsp;&nbsp;&#x27a4;' ),
-						array( &$this, '_pricing_page_render' ),
-						$this->get_plugin_name() . ' &ndash; ' . __fs( 'pricing' ),
-						'manage_options',
-						'pricing',
-						array( &$this, '_clean_admin_content_section' ),
-						WP_FS__LOWEST_PRIORITY,
-						// If user don't have paid plans, add pricing page
-						// to support add-ons checkout but don't add the submenu item.
-						$this->_menu->is_submenu_item_visible( 'pricing' ) && ( $this->has_paid_plan() || ( isset( $_GET['page'] ) && $this->_menu->get_slug( 'pricing' ) == $_GET['page'] ) )
-					);
+					if ( $this->_has_paid_plans ) {
+						$this->add_submenu_item(
+							( $this->is_paying() ? __fs( 'pricing' ) : __fs( 'upgrade' ) . '&nbsp;&nbsp;&#x27a4;' ),
+							array( &$this, '_pricing_page_render' ),
+							$this->get_plugin_name() . ' &ndash; ' . __fs( 'pricing' ),
+							'manage_options',
+							'pricing',
+							array( &$this, '_clean_admin_content_section' ),
+							WP_FS__LOWEST_PRIORITY,
+							// If user don't have paid plans, add pricing page
+							// to support add-ons checkout but don't add the submenu item.
+							$this->_menu->is_submenu_item_visible( 'pricing' ) && ( $this->has_paid_plan() || ( isset( $_GET['page'] ) && $this->_menu->get_slug( 'pricing' ) == $_GET['page'] ) )
+						);
+					}
 				}
 			}
 

--- a/freemius/includes/class-freemius.php
+++ b/freemius/includes/class-freemius.php
@@ -7147,7 +7147,7 @@
 			$this->_logger->entrance();
 
 			if ( $this->is_registered() ) {
-				if ( ! $this->is_paying() && $this->has_paid_plan() ) {
+				if ( ! $this->is_paying() && $this->_has_paid_plans ) {
 					$this->add_plugin_action_link(
 						__fs( 'upgrade' ),
 						$this->get_upgrade_url(),


### PR DESCRIPTION
I wanted to leave a few notes here:

My conditional checks the _has_paid_plans attribute; however, the conditionals only a few lines above this check using a _has_addons function.

I think these should be consistent throughout the code - for example, maybe we could benefit from having a _has_paid_plans function? I'm not sure how you want to keep that structured, but it was kind of confusing having some internal functions using _has_xyz returning their _has_xyz attribute.

Let me know if I can be of any help. :+1: 