### PR TITLE
Fix Multiple Submenu Items in Common Parent Menu

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -1,4 +1,4 @@
-'".WP_PLUGIN_URL."/".$vtaggerdir."/tick.png'<?php
+<?php
 	/**
 	 * @package     Freemius
 	 * @copyright   Copyright (c) 2015, Freemius, Inc.
@@ -29,7 +29,7 @@
 
 		/**
 		 * @since 1.0.0
-'".WP_PLUGIN_URL."/".$vtaggerdir."/tick.png'		 * @var string
+		 * @var string
 		 */
 		private $_plugin_basename;
 		/**

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -1,4 +1,4 @@
-<?php
+'".WP_PLUGIN_URL."/".$vtaggerdir."/tick.png'<?php
 	/**
 	 * @package     Freemius
 	 * @copyright   Copyright (c) 2015, Freemius, Inc.
@@ -29,8 +29,7 @@
 
 		/**
 		 * @since 1.0.0
-		 *
-		 * @var string
+'".WP_PLUGIN_URL."/".$vtaggerdir."/tick.png'		 * @var string
 		 */
 		private $_plugin_basename;
 		/**
@@ -4966,8 +4965,9 @@
 			// Embed all plugin's new submenu items.
 			$this->embed_submenu_items();
 
-			// Start with specially high number to make sure it's appended.
-			$i = 10000;
+			// FIX: Get highest array key value plus one
+			foreach ( $top_level_menu as $submenu_id => $meta ) {$i = $submenu_id + 1;}
+
 			foreach ( $all_submenu_items_after as $meta ) {
 				$top_level_menu[ $i ] = $meta;
 				$i ++;


### PR DESCRIPTION
Setting to a static value here (10000) causes conflicts when multiple instances of this function are called on a common parent menu... 
ie. for branding purposes all my plugins are under the same admin parent menu, and the 10000 value kept overriding the earlier submenus set to the same value, causing them to disappear entirely from the $submenu array and thus the page.
Setting this to the next available (highest submenu item array key) value plus one instead fixes the problem (thoroughly tested here.)
Note: this is really a one-line commit, there are only two commits here because the first edit got mangled.