### PR TITLE
"insufficient permissions" notice on upgrade; missing top level menu

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -6044,8 +6044,8 @@
 			if ( ! $this->has_api_connectivity() && ! $this->enable_anonymous() ) {
 				$this->_menu->remove_menu_item();
 			} else {
-				$this->add_submenu_items();
 				$this->add_menu_action();
+				$this->add_submenu_items();
 			}
 		}
 

--- a/includes/managers/class-fs-admin-menu-manager.php
+++ b/includes/managers/class-fs-admin-menu-manager.php
@@ -527,24 +527,19 @@
 			} else {
 				global $menu;
 
-				$menu_slug = $this->get_slug();
-
 				// Remove original CPT menu.
-				remove_menu_page( $menu_slug );
+				unset( $menu[ $found_menu['position'] ] );
 
 				// Create new top-level menu action.
 				$hookname = add_menu_page(
 					$found_menu['menu'][3],
 					$found_menu['menu'][0],
 					'manage_options',
-					$menu_slug,
+					$this->get_slug(),
 					$function,
 					$found_menu['menu'][6],
 					$found_menu['position']
 				);
-
-				// Remove original CPT menu.
-				//unset( $menu[ $found_menu['position'] ] );
 			}
 
 			return $hookname;

--- a/includes/managers/class-fs-admin-menu-manager.php
+++ b/includes/managers/class-fs-admin-menu-manager.php
@@ -527,19 +527,24 @@
 			} else {
 				global $menu;
 
+				$menu_slug = $this->get_slug();
+
+				// Remove original CPT menu.
+				remove_menu_page( $menu_slug );
+
 				// Create new top-level menu action.
 				$hookname = add_menu_page(
 					$found_menu['menu'][3],
 					$found_menu['menu'][0],
 					'manage_options',
-					$this->get_slug(),
+					$menu_slug,
 					$function,
 					$found_menu['menu'][6],
 					$found_menu['position']
 				);
 
 				// Remove original CPT menu.
-				unset( $menu[ $found_menu['position'] ] );
+				//unset( $menu[ $found_menu['position'] ] );
 			}
 
 			return $hookname;

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '1.1.8.1';
+	$this_sdk_version = '1.1.8.2';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
1.
If the user has skipped opt-in and later decides to upgrade, he will be met by a permission notice when being redirected to the Account page.

This is because the Account is set after actions have run.

2.
Before the user decides to opt-in, the top level menu item is not displayed.
When new overriding menu item is added on the same position, it is immediately removed again by unsetting that position.