### PR TITLE
update .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,7 +2,7 @@ engines:
   phpcodesniffer:
     enabled: true
     config:
-    standard: "WordPress"
+      standard: "WordPress"
 
 ratings:
   paths:


### PR DESCRIPTION
Hey there-

Jenna here from Code Climate. We recieved your message about having some trouble enabling the "WordPress" standard for our phpcodesniffer engine in your .codeclimate.yml file. Really sorry about the trouble you've been having. 

I just tested this out, and I _believe_ the issue is a slight syntax error in your .codeclimate.yml. I added two spaces before the `standard` key in the .codeclimate.yml, and that seems to have addressed all of those "spacing" errors you were seeing your `config.php` file.

Could you try merging in this pr? Once our analysis completes let me know if that gets rid of all those extra errors you're seeing. 

Thanks!
Jenna