### PR TITLE
Fix some issues raised by Theme Check plugin

### DIFF
--- a/config.php
+++ b/config.php
@@ -226,9 +226,6 @@
 
 	if ( WP_FS__ECHO_DEBUG_SDK ) {
 		error_reporting( E_ALL );
-		ini_set( 'error_reporting', E_ALL );
-		ini_set( 'display_errors', true );
-		ini_set( 'html_errors', true );
 	}
 
 

--- a/includes/fs-plugin-info-dialog.php
+++ b/includes/fs-plugin-info-dialog.php
@@ -597,7 +597,7 @@
 											}
 											?>
 											<a class="nav-tab" data-billing-cycle="<?php echo $cycle ?>"
-											   data-pricing="<?php esc_attr_e( json_encode( $prices ) ) ?>">
+											   data-pricing="<?php echo esc_attr( json_encode( $prices ) ) ?>">
 												<?php if ( $is_featured ) : ?>
 													<label>&#9733; <?php _efs( 'best', $api->slug ) ?> &#9733;</label>
 												<?php endif ?>

--- a/templates/account.php
+++ b/templates/account.php
@@ -82,7 +82,7 @@
 			</li>
 			<?php if ( $is_paying ) : ?>
 				<li>
-					&nbsp;•&nbsp;
+					&nbsp;&bull;&nbsp;
 					<form action="<?php echo $fs->_get_admin_page_url( 'account' ) ?>" method="POST">
 						<input type="hidden" name="fs_action" value="deactivate_license">
 						<?php wp_nonce_field( 'deactivate_license' ) ?>
@@ -96,7 +96,7 @@
 				           $is_active_subscription
 				) : ?>
 					<li>
-						&nbsp;•&nbsp;
+						&nbsp;&bull;&nbsp;
 						<form action="<?php echo $fs->_get_admin_page_url( 'account' ) ?>" method="POST">
 							<input type="hidden" name="fs_action" value="downgrade_account">
 							<?php wp_nonce_field( 'downgrade_account' ) ?>
@@ -111,13 +111,13 @@
 					</li>
 				<?php endif ?>
 				<li>
-					&nbsp;•&nbsp;
+					&nbsp;&bull;&nbsp;
 					<a href="<?php echo $fs->get_upgrade_url() ?>"><i
 							class="dashicons dashicons-grid-view"></i> <?php _efs( 'change-plan', $slug ) ?></a>
 				</li>
 			<?php elseif ( $is_paid_trial ) : ?>
 				<li>
-					&nbsp;•&nbsp;
+					&nbsp;&bull;&nbsp;
 					<form action="<?php echo $fs->_get_admin_page_url( 'account' ) ?>" method="POST">
 						<input type="hidden" name="fs_action" value="cancel_trial">
 						<?php wp_nonce_field( 'cancel_trial' ) ?>
@@ -128,7 +128,7 @@
 				</li>
 			<?php endif ?>
 			<li>
-				&nbsp;•&nbsp;
+				&nbsp;&bull;&nbsp;
 				<form action="<?php echo $fs->_get_admin_page_url( 'account' ) ?>" method="POST">
 					<input type="hidden" name="fs_action" value="<?php echo $fs->get_unique_affix() ?>_sync_license">
 					<?php wp_nonce_field( $fs->get_unique_affix() . '_sync_license' ) ?>

--- a/templates/connect.php
+++ b/templates/connect.php
@@ -258,14 +258,14 @@ if ( $is_optin_dialog ) { ?>
 				<a class="fs-trigger" href="#" tabindex="1"><?php _efs( 'what-permissions', $slug ) ?></a>
 				<ul><?php
 						foreach ( $permissions as $id => $permission ) : ?>
-							<li id="fs-permission-<?php esc_attr_e( $id ); ?>"
-							    class="fs-permission fs-<?php esc_attr_e( $id ); ?>">
-								<i class="<?php esc_attr_e( $permission['icon-class'] ); ?>"></i>
+							<li id="fs-permission-<?php echo esc_attr( $id ); ?>"
+							    class="fs-permission fs-<?php echo esc_attr( $id ); ?>">
+								<i class="<?php echo esc_attr( $permission['icon-class'] ); ?>"></i>
 
 								<div>
-									<span><?php esc_html_e( $permission['label'] ); ?></span>
+									<span><?php echo esc_html( $permission['label'] ); ?></span>
 
-									<p><?php esc_html_e( $permission['desc'] ); ?></p>
+									<p><?php echo esc_html( $permission['desc'] ); ?></p>
 								</div>
 							</li>
 						<?php endforeach; ?>

--- a/templates/connect.php
+++ b/templates/connect.php
@@ -53,11 +53,11 @@
     if ( $is_pending_activation ) {
         $require_license_key = false;
     }
-    
+
     if ( $require_license_key ) {
         $fs->_require_license_activation_dialog();
     }
-    
+
 	global $pagenow;
 	$is_theme_page = ( 'themes.php' === $pagenow );
 

--- a/templates/debug.php
+++ b/templates/debug.php
@@ -253,7 +253,7 @@
 			<tr>
 				<td><?php echo $user->id ?></td>
 				<td><?php echo $user->get_name() ?></td>
-				<td><a href="mailto:<?php esc_attr_e( $user->email ) ?>"><?php echo $user->email ?></a></td>
+				<td><a href="mailto:<?php echo esc_attr( $user->email ) ?>"><?php echo $user->email ?></a></td>
 				<td><?php echo json_encode( $user->is_verified ) ?></td>
 				<td><?php echo $user->public_key ?></td>
 				<td><?php echo $user->secret_key ?></td>


### PR DESCRIPTION
Hi,

I found time to fix some issues that Theme Check plugin raises when Freemius SDK is included in the theme. It is only the tip of the iceberg, but it is a start.

## Commit ec6766a

Usually `WP_DEBUG` constant can be used to achieve full reporting. Maybe I missed something?

## Commit 349897f

`esc_attr_e` and `esc_html_e` are i18n functions merged with sanitization functions. If you're printing out a variable, the respective `esc_attr` and `esc_html` should be used (no `_e` at the end).

## Commit ff2a340

ASCII characters are safe in files. I changed the bullet char with the HTML entity `&bull;`.

---

Sharing my view on the rest of the errors:

- `WARNING: Found a translation function that is missing a text-domain.`

  You will need to go through each of these and add text-domains.

- `WARNING: Found base64_encode in the file ...`

  @vovafeldman mentioned the hack in the email, I left these untouched.

- `WARNING: fopen/fclose/curl_* was found in the file ...`

  It will take me too much time to reverse engineer this code. It is best that you refactor this code, using `WP_Filesystem` and/or HTTP API, so you don't need to use these functions directly anymore.

- `REQUIRED: ... Themes should use add_theme_page() for adding admin pages.`

  All instances of `add_menu_page`, `add_submenu_page` and `add_debug_page` should be replaced with `add_theme_page`. If you need some these pages for testing/debugging, I would recommend that you put somewhere in docs which files can be removed during the preparation of the theme for upload, so the code triggering errors can be removed upon testing.

After that there are lots of INFO notices, which AFAIK are not required to follow, but I would strive to fix as many of these as well.

Primoz