### PR TITLE
Ignore single-file-plugins when finding the SDK location

### DIFF
--- a/includes/supplements/fs-essential-functions-1.1.7.1.php
+++ b/includes/supplements/fs-essential-functions-1.1.7.1.php
@@ -37,7 +37,9 @@
 		// Get active plugin's main files real full names (might be symlinks).
 		foreach ( $all_plugins as $relative_path => &$data ) {
 			if ( 0 === strpos( $file_real_path, fs_normalize_path( dirname( realpath( WP_PLUGIN_DIR . '/' . $relative_path ) ) ) ) ) {
-				return $relative_path;
+				if ( '.' !== dirname( trailingslashit( $relative_path ) ) ) {
+	                return $relative_path;
+	            }
 			}
 		}
 


### PR DESCRIPTION
The SDK path is incorrectly detected if there are any single-file-plugins that are listed earlier in the plugin list. Ignore single-file-plugins to fix this.