### PR TITLE
NPM Module Cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,18 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "main": "gulpfile.js",
-  "dependencies": {
-    "gulp": "^3.9.1",
-    "gulp-clean": "^0.3.2",
-    "gulp-fs": "0.0.2",
-    "gulp-gettext": "^0.3.0",
-    "gulp-path": "^3.0.3",
-    "gulp-pofill": "^1.0.0",
-    "gulp-rename": "^1.2.2",
-    "gulp-sort": "^2.0.0",
-    "gulp-wp-pot": "^2.0.4",
-    "gulp-transifex": "^0.1.17"
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -25,6 +13,7 @@
   "author": "Vova Feldman",
   "license": "GPL-2.0",
   "homepage": "https://freemius.com",
+  "dependencies": {},
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prune": "rimraf .codeclimate.yml .git .github .gitignore .travis.yml gulpfile.js composer.json"
   },
   "repository": {
     "type": "git",
@@ -23,7 +24,8 @@
     "gulp-pofill": "^1.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-sort": "^2.0.0",
+    "gulp-transifex": "^0.1.17",
     "gulp-wp-pot": "^2.0.4",
-    "gulp-transifex": "^0.1.17"
+    "rimraf": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,18 +1,15 @@
 {
   "name": "freemius-wordpress-sdk",
-  "version": "1.0.0",
-  "description": "",
+  "description": "Monetization, analytics, and marketing automation platform for plugin & theme developers.",
+  "author": "Vova Feldman",
+  "version": "1.0.0-development",
+  "private": true,
   "main": "gulpfile.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prune": "rimraf .codeclimate.yml .git .github .gitignore .travis.yml gulpfile.js composer.json"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Freemius/wordpress-sdk.git"
-  },
-  "author": "Vova Feldman",
-  "license": "GPL-2.0",
+  "repository": "Freemius/wordpress-sdk.git",
   "homepage": "https://freemius.com",
   "dependencies": {},
   "devDependencies": {
@@ -27,5 +24,6 @@
     "gulp-transifex": "^0.1.17",
     "gulp-wp-pot": "^2.0.4",
     "rimraf": "^2.6.1"
-  }
+  },
+  "license": "GPL-2.0"
 }


### PR DESCRIPTION
Broken into three commits, explained here:

- d79c55c empties `dependencies` object as this module has no hard dependencies
- 6dad57c adds an NPM script to prune unnecessary files (based on docs and some ad libbing)
- bf9439f sets NPM module as private, adjusts version and simplifies the package manifest