### PR TITLE
[license] [activation] [email] When activating with a license key and…

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -8237,13 +8237,21 @@
 				$fs_user = Freemius::_get_user_by_email( $email );
 
 				if ( is_object( $fs_user ) ) {
+					/**
+					 * If opting in with a context license and the context WP Admin user already opted in
+					 * before from the current site, add the user context security params to avoid the
+					 * unnecessry email activation when the context license is owned by the same context user.
+					 * 
+					 * @author Leo Fajardo (@leorw)
+					 * @since 1.2.3
+					 */
 					$params = array_merge( $params, FS_Security::instance()->get_context_params(
 						$fs_user,
 						false,
 						'install_with_existing_user'
 					) );
 				}
-            }
+			}
 
 			$params['format'] = 'json';
 

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -8233,6 +8233,18 @@
 				);
 			}
 
+			if ( isset( $params['license_key'] ) ) {
+				$fs_user = Freemius::_get_user_by_email( $email );
+
+				if ( is_object( $fs_user ) ) {
+					$params = array_merge( $params, FS_Security::instance()->get_context_params(
+						$fs_user,
+						false,
+						'install_with_existing_user'
+					) );
+				}
+            }
+
 			$params['format'] = 'json';
 
 			$url = WP_FS__ADDRESS . '/action/service/user/install/';
@@ -8308,7 +8320,9 @@
 			} else if ( isset( $decoded->pending_activation ) && $decoded->pending_activation ) {
 				// Pending activation, add message.
 				return $this->set_pending_confirmation(
-					true,
+                    ( isset( $decoded->email ) ?
+                        $decoded->email :
+                        true ),
 					false,
 					$filtered_license_key,
 					! empty( $params['trial_plan_id'] )


### PR DESCRIPTION
… there's already a context user in the site's database (even non-registered), include the user data in the activation request.