### PR TITLE
Can conflict with other requests with that use the 'action' request key

### DIFF
--- a/includes/fs-core-functions.php
+++ b/includes/fs-core-functions.php
@@ -164,14 +164,18 @@
 
 	function fs_get_action( $action_key = 'action' ) {
 		if ( ! empty( $_REQUEST[ $action_key ] ) ) {
-			return strtolower( $_REQUEST[ $action_key ] );
+			if ( is_string( $_REQUEST[ $action_key ] ) ) {
+				return strtolower( $_REQUEST[ $action_key ] );
+			}
 		}
 
 		if ( 'action' == $action_key ) {
 			$action_key = 'fs_action';
 
 			if ( ! empty( $_REQUEST[ $action_key ] ) ) {
-				return strtolower( $_REQUEST[ $action_key ] );
+				if ( is_string( $_REQUEST[ $action_key ] ) ) {
+					return strtolower( $_REQUEST[ $action_key ] );
+				}
 			}
 		}
 


### PR DESCRIPTION
I encountered a plugin that performed their own custom ajax posts which were intercepted by the Freemius SDK. The SDK errored out because the `$_REQUEST` value was an array.