### PR TITLE
Fix to class-freemius.php displaying 1 instead of the literal plugin

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -5800,7 +5800,7 @@
 					$this->get_text( 'theme' ) );
 
 			if ( $lowercase ) {
-				$label = strtolower( $lowercase );
+				$label = strtolower( $label );
 			}
 
 			return $label;


### PR DESCRIPTION
Code inadvertently converts 'true' to lowercase rather than the literal string, hence displaying 1 - as per issue raised on  Slack