### PR TITLE
Fix get_module_label function to return correct label 💯

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -2259,7 +2259,7 @@
 
 			return ( checkdnsrr( $domain, 'MX' ) || checkdnsrr( $domain, 'A' ) );
 		}
-		
+
 		/**
 		 * Generate API connectivity issue message.
 		 *
@@ -3751,7 +3751,7 @@
 			     ! $this->has_features_enabled_license() &&
 			     ! $this->_has_premium_license()
 			) {
-				if ( $this->is_registered() ) {				
+				if ( $this->is_registered() ) {
 					// IF wrapper is turned off because activation_timestamp is currently only stored for plugins (not addons).
 	//                if (empty($this->_storage->activation_timestamp) ||
 	//                    (WP_FS__SCRIPT_START_TIME - $this->_storage->activation_timestamp) > 30
@@ -5800,7 +5800,7 @@
 					$this->get_text( 'theme' ) );
 
 			if ( $lowercase ) {
-				$label = strtolower( $lowercase );
+				$label = strtolower( $label );
 			}
 
 			return $label;


### PR DESCRIPTION
Hi guys,

`get_module_label` function, in `class-freemius.php`, was returning `string 1` because the label in the function was getting replaced by `$lowercase` variable.

I have corrected the mistake and sending a pull request.

### Screenshot

![alt text](https://cl.ly/oDGI/🎯 "Screenshot of error")

Cheers!