### PR TITLE
[affiliation] [bug-fix] [major] Cached the result of the API calls th…

### DIFF
--- a/config.php
+++ b/config.php
@@ -285,6 +285,9 @@
 	if ( ! defined( 'WP_FS__TIME_24_HOURS_IN_SEC' ) ) {
 		define( 'WP_FS__TIME_24_HOURS_IN_SEC', 86400 );
 	}
+	if ( ! defined( 'WP_FS__TIME_WEEK_IN_SEC' ) ) {
+		define( 'WP_FS__TIME_WEEK_IN_SEC', 7 * WP_FS__TIME_24_HOURS_IN_SEC );
+	}
 
 	#--------------------------------------------------------------------------------
 	#region Debugging

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -13205,13 +13205,6 @@
                 return false;
 			}
 
-            $this->fetch_affiliate_and_custom_terms();
-
-            if ( is_object( $this->affiliate ) ) {
-                // User is already an affiliate.
-                return false;
-            }
-
 			$message = sprintf(
 				$this->get_text_inline( 'Hey there, did you know that %s has an affiliate program? If you like the %s you can become our ambassador and earn some cash!', 'become-an-ambassador-admin-notice' ),
 				sprintf( '<strong>%s</strong>', $this->get_plugin_name() ),

--- a/templates/forms/affiliation.php
+++ b/templates/forms/affiliation.php
@@ -365,7 +365,7 @@
                     beforeSend: function() {
                         $cancelButton.addClass( 'disabled' );
                         $submitButton.addClass( 'disabled' );
-                        $submitButton.text( '<?php fs_esc_js_inline( 'Processing', 'processing' ) ?>...' );
+                        $submitButton.text( '<?php fs_esc_js_echo_inline( 'Processing', 'processing' ) ?>...' );
                     },
                     success   : function( result ) {
                         if ( result.success ) {


### PR DESCRIPTION
…at fetch the affiliation data and fetch the affiliation data only when determining further if an affiliation-related admin notice should be shown, when the "Affiliation" page is loaded, and when submitting an affiliate application via the API.