### PR TITLE
[add-ons] fix dialogs and links in Plugins list

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -7610,6 +7610,10 @@
 		function pricing_url( $billing_cycle = WP_FS__PERIOD_ANNUALLY, $is_trial = false ) {
 			$this->_logger->entrance();
 
+			if($this->is_addon() && $this->is_only_premium()) {
+				return $this->_parent->addon_url($this->_slug);
+			}
+
 			$params = array(
 				'billing_cycle' => $billing_cycle
 			);

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -13384,7 +13384,7 @@
 		function _add_license_action_link() {
 			$this->_logger->entrance();
 
-			if ( $this->is_free_plan() && $this->is_addon() ) {
+			if ( $this->is_free_plan() && !$this->is_only_premium() && $this->is_addon() ) {
 				return;
 			}
 

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -3062,6 +3062,19 @@
 				// Check if Freemius is on for the current plugin.
 				// This MUST be executed after all the plugin variables has been loaded.
 				if ( ! $this->is_on() ) {
+
+					//Load add-on modals when Freemius is OFF
+					if ( $this->is_user_in_admin() ) {
+						if ( $this->is_plugin() && $this->has_addons() &&
+						     'plugin-information' === fs_request_get( 'tab', false ) &&
+						     $this->get_id() == fs_request_get( 'parent_plugin_id', false )
+						) {
+							require_once WP_FS__DIR_INCLUDES . '/fs-plugin-info-dialog.php';
+
+							new FS_Plugin_Info_Dialog( $this );
+						}
+					}
+
 					return;
 				}
 			}


### PR DESCRIPTION
- [x] Load Add-ons dialog when **Freemius State = OFF**
- [x] Direct **upgrade_url** to dialog for premium-only add-ons (instead of non-existing pricing page). Not tested if it should also be done for freemium add-ons
- [x] When a user deactivates license for a premium-only add-on, show link to **"Activate License"** in the Plugins list. Before this, user had to deactivate/activate add-on again to reactivate license.
