### PR TITLE
[api] [curl] In the API requests, include the "Expect" header param o…

### DIFF
--- a/includes/sdk/FreemiusWordPress.php
+++ b/includes/sdk/FreemiusWordPress.php
@@ -390,9 +390,11 @@
 
 			$resource = explode( '?', $pCanonizedPath );
 
-			// Disable the 'Expect: 100-continue' behaviour. This causes cURL to wait
-			// for 2 seconds if the server does not support this header.
-			$pWPRemoteArgs['headers']['Expect'] = '';
+            if ( FS_SDK__HAS_CURL ) {
+                // Disable the 'Expect: 100-continue' behaviour. This causes cURL to wait
+                // for 2 seconds if the server does not support this header.
+                $pWPRemoteArgs['headers']['Expect'] = '';
+            }
 
 			if ( 'https' === substr( strtolower( $request_url ), 0, 5 ) ) {
 				$pWPRemoteArgs['sslverify'] = false;


### PR DESCRIPTION
…nly if cURL is enabled. Otherwise, it will be included in the HTTP request headers with an empty value and will trigger an expectation failure.