### PR TITLE
fix redirects loop if  unactive parent theme has latest sdk version

### DIFF
--- a/start.php
+++ b/start.php
@@ -179,6 +179,12 @@
 		} else {
 			$current_theme               = wp_get_theme();
 			$is_newest_sdk_plugin_active = ( $current_theme->stylesheet === $fs_newest_sdk->plugin_path );
+
+			$current_theme_parent = $current_theme->parent();
+
+			if(!$is_newest_sdk_plugin_active && $current_theme_parent instanceof WP_Theme){
+				$is_newest_sdk_plugin_active = ($fs_newest_sdk->plugin_path === $current_theme_parent->stylesheet);
+			}
 		}
 
 		if ( $is_current_sdk_newest &&


### PR DESCRIPTION
Fix redirect loop issue. This issue can be reproduced when parent them have latest sdk version and child theme(without freemius sdk) is active and there are active plugins with old freemius sdk