### PR TITLE
[theme] [activation] [bug-fix] Fixed a redirects loop issue that was …

### DIFF
--- a/start.php
+++ b/start.php
@@ -179,6 +179,16 @@
 		} else {
 			$current_theme               = wp_get_theme();
 			$is_newest_sdk_plugin_active = ( $current_theme->stylesheet === $fs_newest_sdk->plugin_path );
+
+            $current_theme_parent = $current_theme->parent();
+
+            /**
+             * If the current theme is a child of the theme that has the newest SDK, this prevents a redirects loop
+             * from happening by keeping the SDK info stored in the `fs_active_plugins` option.
+             */
+            if ( ! $is_newest_sdk_plugin_active && $current_theme_parent instanceof WP_Theme ) {
+                $is_newest_sdk_plugin_active = ( $fs_newest_sdk->plugin_path === $current_theme_parent->stylesheet );
+            }
 		}
 
 		if ( $is_current_sdk_newest &&


### PR DESCRIPTION
…happening when activating a child theme whose parent is using the latest SDK version.

Reference to the original PR:
https://github.com/Freemius/wordpress-sdk/pull/229