### PR TITLE
Check REQUEST_METHOD is set

### DIFF
--- a/config.php
+++ b/config.php
@@ -163,6 +163,7 @@
 
     if ( ! defined( 'WP_FS__IS_POST_REQUEST' ) ) {
         define( 'WP_FS__IS_POST_REQUEST', ( WP_FS__IS_HTTP_REQUEST &&
+                                            isset( $_SERVER['REQUEST_METHOD'] ) &&
                                             strtoupper( $_SERVER['REQUEST_METHOD'] ) == 'POST' ) );
     }
 


### PR DESCRIPTION
A user of one of my plugins was getting a warning about `$_SERVER['REMOTE_METHOD']` not being defined when running from the CLI. It turns out he was defining `$_SERVER['HTTP_HOST']` to work around other issues, and the code assumes that if `HTTP_HOST` is set then `REMOTE_METHOD` must also be set.

This PR just checks `REMOTE_METHOD` is actually set before using it.