### PR TITLE
Overly Cautious Sanitization to Stop False Flags

### DIFF
--- a/includes/fs-core-functions.php
+++ b/includes/fs-core-functions.php
@@ -142,13 +142,13 @@
 
             switch ( $type ) {
                 case 'post':
-                    $value = isset( $_POST[ $key ] ) ? $_POST[ $key ] : $def;
+                    $value = isset( $_POST[ $key ] ) ? sanitize_text_field( $_POST[ $key ] ) : $def;
                     break;
                 case 'get':
-                    $value = isset( $_GET[ $key ] ) ? $_GET[ $key ] : $def;
+                    $value = isset( $_GET[ $key ] ) ? sanitize_text_field( $_GET[ $key ] ) : $def;
                     break;
                 default:
-                    $value = isset( $_REQUEST[ $key ] ) ? $_REQUEST[ $key ] : $def;
+                    $value = isset( $_REQUEST[ $key ] ) ? sanitize_text_field( $_REQUEST[ $key ] ) : $def;
                     break;
             }
 
@@ -202,7 +202,7 @@
                 $action_key = 'fs_action';
 
                 if ( ! empty( $_REQUEST[ $action_key ] ) && is_string( $_REQUEST[ $action_key ] ) ) {
-                    return strtolower( $_REQUEST[ $action_key ] );
+                    return strtolower( sanitize_text_field( $_REQUEST[ $action_key ] ) );
                 }
             }
 

--- a/includes/managers/class-fs-admin-notice-manager.php
+++ b/includes/managers/class-fs-admin-notice-manager.php
@@ -175,7 +175,7 @@
          *
          */
         function dismiss_notice_ajax_callback() {
-            $this->_sticky_storage->remove( $_POST['message_id'] );
+            $this->_sticky_storage->remove( absint( $_POST['message_id'] ) );
             wp_die();
         }
 


### PR DESCRIPTION
Whenever we run a scan of a plugin using Freemius, we have to double check that this is safe.

The answer is: It could be SAFER and stop throwing red-flags if you just act extra paranoid.

It would benefit users as well to see that you're going that extra mile to make ABSOLUTELY sure people can't do stupid things to the code library they're using.

Yes, it's overkill, but I firmly believe that staying one half-step ahead of hackers means being paranoid.