### PR TITLE
Feature/premium plan activation notice fix

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -18032,7 +18032,7 @@
                             $this->_store_licenses();
 
                             $plan_change = $is_free ?
-                                'upgraded' :
+                                ( $this->is_only_premium() ? 'activated' : 'upgraded' ) :
                                 ( is_object( $new_license ) ?
                                     'changed' :
                                     'downgraded' );
@@ -18093,11 +18093,12 @@
                         }
                         break;
                     case 'upgraded':
+                    case 'activated':
                         $this->_admin_notices->add_sticky(
-                            sprintf(
-                                $this->get_text_inline( 'Your plan was successfully upgraded.', 'plan-upgraded-message' ),
-                                '<i>' . $this->get_plugin_name() . '</i>'
-                            ) . $this->get_complete_upgrade_instructions(),
+                            ( 'activated' === $plan_change ) ?
+                                $this->get_text_inline( 'Your plan was successfully activated.', 'plan-activated-message' ) :
+                                $this->get_text_inline( 'Your plan was successfully upgraded.', 'plan-upgraded-message' ) .
+                            $this->get_complete_upgrade_instructions(),
                             'plan_upgraded',
                             $this->get_text_x_inline( 'Yee-haw', 'interjection expressing joy or exuberance', 'yee-haw' ) . '!'
                         );

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -7183,6 +7183,18 @@
                 } else {
                     $this->maybe_network_activate_addon_license();
                 }
+
+                /**
+                 * Avoid redirecting to the license activation screen after automatically activating an add-on license.
+                 *
+                 * @author Leo Fajardo (@leorw)
+                 * @since 2.2.4.12
+                 */
+                $is_trial_or_has_features_enabled_license = ( $this->is_trial() || $this->has_features_enabled_license() );
+
+                if ( $is_trial_or_has_features_enabled_license && true === $this->_storage->require_license_activation ) {
+                    $this->_storage->require_license_activation = false;
+                }
             }
 
             if (

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.2.4.11';
+	$this_sdk_version = '2.2.4.12';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
- Fixed the admin notice that is shown after automatically activating an add-on license.
- Prevents redirecting to the license activation screen after an automatic license activation.