### PR TITLE
Update WP Engine URLs recognized as localhost

### DIFF
--- a/includes/entities/class-fs-site.php
+++ b/includes/entities/class-fs-site.php
@@ -168,9 +168,8 @@
                 fs_ends_with( $subdomain, '.wpsandbox.pro' ) ||
                 // SiteGround staging.
                 fs_starts_with( $subdomain, 'staging' ) ||
-                // WPEngine staging.
-                fs_ends_with( $subdomain, '.staging.wpengine.com' ) ||
-                fs_ends_with( $subdomain, '.dev.wpengine.com' ) ||
+                // WPEngine environments.
+                fs_ends_with( $subdomain, '.wpengine.com' ) ||
                 // Pantheon
                 ( fs_ends_with($subdomain, 'pantheonsite.io') &&
                   (fs_starts_with($subdomain, 'test-') || fs_starts_with($subdomain, 'dev-'))) ||


### PR DESCRIPTION
WP Engine no longer creates environments with `.dev.` or `.staging.`<sup>1</sup> in the URL. All environments are now of the format `*.wpengine.com`. Those URLs cannot be used as production URLs any more than the old `.dev.` or `.staging.` because they force `noindex`, among other things.

One note, WP Engine creates a global called `$wpe_all_domains`.  In the staging and dev environments, the variable should be an array with a length of 1. However, it's not reliable due to common misconfigurations. That said, the URL method should certainly be sufficient.

I look forward to seeing this updated as soon as possible. A number of key plugins leverage this system and this functional gap is causing serious maintenance issues across large groups of sites.

Thanks!
<br>
<br>
<br>
<br>
<sup>1</sup>these URLs could exist, but they are considered "legacy"
<br>