### PR TITLE
Do not override WordPress.org plugin descriptions inheritance

### DIFF
--- a/includes/fs-plugin-info-dialog.php
+++ b/includes/fs-plugin-info-dialog.php
@@ -328,7 +328,15 @@
                 }
             }
 
-            $data->sections['description'] = fs_get_template( '/plugin-info/description.php', $view_vars );
+            $description = fs_get_template( '/plugin-info/description.php', $view_vars );
+            $description = trim( $description );
+
+            $description = $this->_fs->apply_filters( 'plugin_section_description', $description, $data );
+
+            // Only override description if it's not empty or not set yet.
+            if ( '' !== $description || ! isset( $data->sections['description'] ) ) {
+                $data->sections['description'] = $description;
+            }
 
             if ( $has_pricing ) {
                 // Add plans to data.

--- a/templates/plugin-info/description.php
+++ b/templates/plugin-info/description.php
@@ -32,7 +32,11 @@
 				<?php endfor ?>
 			</ul>
 		</div>
-	<?php endif ?>
+	<?php
+	endif;
+	
+	if ( ! empty( $plugin->info->description ) ) :
+	?>
 	<div>
 		<?php
 			echo wp_kses( $plugin->info->description, array(
@@ -49,7 +53,10 @@
 			) );
 		?>
 	</div>
-<?php if ( ! empty( $plugin->info->screenshots ) ) : ?>
+	<?php
+	endif;
+
+	if ( ! empty( $plugin->info->screenshots ) ) : ?>
 	<?php $screenshots = $plugin->info->screenshots ?>
 	<div class="fs-screenshots clearfix">
 		<h2><?php fs_esc_html_echo_inline( 'Screenshots', 'screenshots', $plugin->slug ) ?></h2>
@@ -75,4 +82,5 @@
 					<?php $i ++; endforeach ?>
 		</ul>
 	</div>
-<?php endif ?>
+	<?php
+	endif;

--- a/templates/plugin-info/description.php
+++ b/templates/plugin-info/description.php
@@ -20,7 +20,8 @@
 	if ( ! empty( $plugin->info->selling_point_0 ) ||
 	     ! empty( $plugin->info->selling_point_1 ) ||
 	     ! empty( $plugin->info->selling_point_2 )
-	) : ?>
+	) :
+	?>
 		<div class="fs-selling-points">
 			<ul>
 				<?php for ( $i = 0; $i < 3; $i ++ ) : ?>
@@ -56,7 +57,8 @@
 	<?php
 	endif;
 
-	if ( ! empty( $plugin->info->screenshots ) ) : ?>
+	if ( ! empty( $plugin->info->screenshots ) ) :
+	?>
 	<?php $screenshots = $plugin->info->screenshots ?>
 	<div class="fs-screenshots clearfix">
 		<h2><?php fs_esc_html_echo_inline( 'Screenshots', 'screenshots', $plugin->slug ) ?></h2>


### PR DESCRIPTION
This PR will prevent the empty Freemius add-on description from overriding the WordPress.org plugin description and adds a new filter to customize the description further.