### PR TITLE
[caller-plugin] Fixed an issue with the caller plugin file finder log…

### DIFF
--- a/includes/supplements/fs-essential-functions-1.1.7.1.php
+++ b/includes/supplements/fs-essential-functions-1.1.7.1.php
@@ -32,7 +32,7 @@
 
 		// Get active plugin's main files real full names (might be symlinks).
 		foreach ( $all_plugins as $relative_path => $data ) {
-			if ( 0 === strpos( $file_real_path, fs_normalize_path( dirname( realpath( WP_PLUGIN_DIR . '/' . $relative_path ) ) ) ) ) {
+            if ( 0 === strpos( $file_real_path, fs_normalize_path( dirname( realpath( WP_PLUGIN_DIR . '/' . $relative_path ) ) . '/' ) ) ) {
 				if ( '.' !== dirname( trailingslashit( $relative_path ) ) ) {
 	                return $relative_path;
 	            }

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.3.2.12';
+	$this_sdk_version = '2.3.2.13';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
…ic that occurs when the free and premium versions of some plugins need to be active at the same time and the premium version is using the default directory name (i.e., {slug}-premium). In this case, if only the premium version is integrated with the SDK, since its directory name starts with the free version's directory name, the free version's plugin basename can be mistakenly added as the first item in the active_plugins database option instead of the premium version's plugin basename which results to unexpected issues.