### PR TITLE
[bundle] [license] Handled the case when the core plugin is network-a…

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -4941,6 +4941,12 @@
                             $premium_license = null;
 
                             if ( ! $this->has_free_plan() && $this->_parent->has_features_enabled_bundle_license() ) {
+                                /**
+                                 * If the add-on has no free plan, try to activate with a bundle license if there's any.
+                                 *
+                                 * @author Leo Fajardo (@leorw)
+                                 * @since 2.3.3
+                                 */
                                 $bundle_license = $this->get_active_parent_license( $this->_parent->_get_license()->secret_key, false );
 
                                 if (
@@ -17456,16 +17462,26 @@
             );
 
             if ( ! $this->is_api_result_object( $result, 'installs' ) ) {
-                $error_message = FS_Api::is_api_error_object( $result ) ?
-                    $result->error->message :
-                    $this->get_text_inline( 'An unknown error has occurred.', 'unknown-error' );
+                /**
+                 * When a license key is provided, it's an attempt by the SDK to activate a bundle license and not a user-initiated action, therefore, do not show any admin notice to avoid confusion (e.g.: it will show up just above the opt-in link). If the license activation fails, the admin will see an opt-in link instead.
+                 *
+                 * @author Leo Fajardo (@leorw)
+                 * @since 2.3.3
+                 */
+                $background = ( ! empty( $license_key ) );
 
-                $this->_admin_notices->add(
-                    sprintf( $this->get_text_inline( 'Couldn\'t activate %s.', 'could-not-activate-x' ), $this->get_plugin_name() ) . ' ' .
-                    $this->get_text_inline( 'Please contact us with the following message:', 'contact-us-with-error-message' ) . ' ' . '<b>' . $error_message . '</b>',
-                    $this->get_text_x_inline( 'Oops', 'exclamation', 'oops' ) . '...',
-                    'error'
-                );
+                if ( ! $background ) {
+                    $error_message = FS_Api::is_api_error_object( $result ) ?
+                        $result->error->message :
+                        $this->get_text_inline( 'An unknown error has occurred.', 'unknown-error' );
+
+                    $this->_admin_notices->add(
+                        sprintf( $this->get_text_inline( 'Couldn\'t activate %s.', 'could-not-activate-x' ), $this->get_plugin_name() ) . ' ' .
+                        $this->get_text_inline( 'Please contact us with the following message:', 'contact-us-with-error-message' ) . ' ' . '<b>' . $error_message . '</b>',
+                        $this->get_text_x_inline( 'Oops', 'exclamation', 'oops' ) . '...',
+                        'error'
+                    );
+                }
 
                 return;
             }

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -17409,9 +17409,9 @@
          *
          * @param Freemius      $parent_fs
          * @param bool|int|null $network_level_or_blog_id True for network level opt-in and integer for opt-in for specified blog in the network.
-         * @param string|null   $license_key
+         * @param string|null   $bundle_license_key
          */
-        private function _activate_addon_account( Freemius $parent_fs, $network_level_or_blog_id = null, $license_key = null ) {
+        private function _activate_addon_account( Freemius $parent_fs, $network_level_or_blog_id = null, $bundle_license_key = null ) {
             if ( $this->is_registered() ) {
                 // Already activated.
                 return;
@@ -17450,8 +17450,8 @@
                 }
             }
 
-            if ( ! empty( $license_key ) ) {
-                $params['license_key'] = $license_key;
+            if ( ! empty( $bundle_license_key) ) {
+                $params['license_key'] = $bundle_license_key;
             }
 
             // Activate add-on with parent plugin credentials.
@@ -17468,7 +17468,7 @@
                  * @author Leo Fajardo (@leorw)
                  * @since 2.3.3
                  */
-                $background = ( ! empty( $license_key ) );
+                $background = ( ! empty( $bundle_license_key) );
 
                 if ( ! $background ) {
                     $error_message = FS_Api::is_api_error_object( $result ) ?

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -351,6 +351,14 @@
          */
         private $is_whitelabeled;
 
+        /**
+         * @author Leo Fajardo (@leorw)
+         * @since 2.3.3
+         *
+         * @var bool
+         */
+        private $_enable_bundle_license_auto_activation;
+
         #region Uninstall Reasons IDs
 
         const REASON_NO_LONGER_NEEDED = 1;
@@ -5655,6 +5663,7 @@
                 $this->_anonymous_mode   = $this->get_bool_option( $plugin_info, 'anonymous_mode', false );
             }
             $this->_permissions = $this->get_option( $plugin_info, 'permissions', array() );
+            $this->_enable_bundle_license_auto_activation = $this->get_option( $plugin_info, 'bundle_license_auto_activation', false );
 
             if ( ! empty( $plugin_info['trial'] ) ) {
                 $this->_trial_days = $this->get_numeric_option(
@@ -7868,7 +7877,10 @@
                 return;
             }
 
-            if ( ! empty( $license->products ) ) {
+            if (
+                $this->is_bundle_license_auto_activation_enabled() &&
+                ! empty( $license->products )
+            ) {
                 $this->activate_bundle_license( $license );
 
                 return;
@@ -7917,7 +7929,10 @@
                 return;
             }
 
-            if ( ! empty( $license->products ) ) {
+            if (
+                $this->is_bundle_license_auto_activation_enabled() &&
+                ! empty( $license->products )
+            ) {
                 $this->activate_bundle_license( $license );
 
                 return;
@@ -10660,6 +10675,16 @@
         }
 
         /**
+         * @author Leo Fajardo (@leorw)
+         * @since  2.3.3
+         *
+         * @return bool
+         */
+        function is_bundle_license_auto_activation_enabled() {
+            return $this->_enable_bundle_license_auto_activation;
+        }
+
+        /**
          * @author Vova Feldman (@svovaf)
          * @since  1.0.4
          *
@@ -13156,7 +13181,10 @@
                 fs_request_get_bool( 'is_extensions_tracking_allowed', true )
             );
 
-            if ( $result['success'] ) {
+            if (
+                $result['success'] &&
+                $this->is_bundle_license_auto_activation_enabled()
+            ) {
                 $license             = new FS_Plugin_License();
                 $license->secret_key = $license_key;
 
@@ -17517,7 +17545,9 @@
                 // Try to activate premium license.
                 $this->_activate_license( true );
 
-                $this->maybe_activate_bundle_license( $bundle_license );
+                if ( $this->is_bundle_license_auto_activation_enabled() ) {
+                    $this->maybe_activate_bundle_license( $bundle_license );
+                }
             } else {
                 if ( is_object( $bundle_license ) ) {
                     $premium_license = $bundle_license;
@@ -21990,7 +22020,9 @@
                          */
                         unset( $_REQUEST['plugin_id'] );
 
-                        $fs->maybe_activate_bundle_license( null, array(), is_numeric( $blog_id ) ? $blog_id : 0 );
+                        if ( $this->is_bundle_license_auto_activation_enabled() ) {
+                            $fs->maybe_activate_bundle_license( null, array(), is_numeric( $blog_id ) ? $blog_id : 0 );
+                        }
                     }
 
                     return;

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -10686,7 +10686,7 @@
          */
         function is_bundle_license_auto_activation_enabled() {
             return $this->is_addon() ?
-                $this->_parent->is_bundle_license_auto_activation_enabled() :
+                ( is_object( $this->_parent ) && $this->_parent->is_bundle_license_auto_activation_enabled() ) :
                 $this->_is_bundle_license_auto_activation_enabled;
         }
 


### PR DESCRIPTION
…ctive and activated with a bundle license, and an add-on is site-level–activated and the bundle license needs to be activated for the add-on.