### PR TITLE
fs_dynamic_init's paramter type fix

### DIFF
--- a/start.php
+++ b/start.php
@@ -512,7 +512,7 @@
 		}
 
 		/**
-		 * @param array <string,string> $module Plugin or Theme details.
+		 * @param array <string,string|bool|array> $module Plugin or Theme details.
 		 *
 		 * @return Freemius
 		 * @throws Freemius_Exception


### PR DESCRIPTION
Plugin info can contain booleans and arrays too.