### PR TITLE
Feature/highlight package of single plan

### DIFF
--- a/templates/pricing.php
+++ b/templates/pricing.php
@@ -137,6 +137,7 @@
             ),
             'selector'            => '#fs_pricing_wrapper',
             'unique_affix'        => $fs->get_unique_affix(),
+            'featured_pricing_id' => 1690
         ), $query_params );
 
         wp_add_inline_script( 'freemius-pricing', 'Freemius.pricing.new( ' . json_encode( $pricing_config ) . ' )' );


### PR DESCRIPTION
- [pricing] [package] [single-plan] [highlight] Introduced a new 'feature_pricing_id' option to highlight the specific package when the product has only one plan.