### PR TITLE
Feature/promo tab bug fix

### DIFF
--- a/assets/scss/admin/common.scss
+++ b/assets/scss/admin/common.scss
@@ -148,7 +148,7 @@ div.fs-notice
     }
 }
 
-@media screen and (max-width: 500px) {
+@media screen and (max-width: 1250px) {
     #fs_promo_tab
     {
         display: none;


### PR DESCRIPTION
- [pricing] [promo-tab] [bug-fix] Hide the promo tab on the pricing page(max-width: 1250px) since it can overwrap the right navigation arrow.