### PR TITLE
Feature/opt in notice issue

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -23401,6 +23401,14 @@
                 return;
             }
 
+            if (
+                $this->is_addon() &&
+                ! $this->is_only_premium() &&
+                $this->_parent->is_anonymous()
+            ) {
+                return;
+            }
+
             if ( fs_is_network_admin() ) {
                 if ( ! $this->_is_network_active ) {
                     // Don't add tracking links when browsing the network WP Admin and the plugin is not network active.

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -7234,7 +7234,8 @@
                         }
 
                         if ( $this->is_plugin_new_install() || $this->is_only_premium() ) {
-                            if ( ! $this->_anonymous_mode ) {
+                            if ( ! $this->_anonymous_mode &&
+                                 ( ! $this->is_addon() || ( ! $this->_parent->_is_anonymous && ! $this->_parent->_anonymous_mode ) ) ) {
                                 // Show notice for new plugin installations.
                                 $this->_admin_notices->add(
                                     sprintf(
@@ -7285,6 +7286,11 @@
          * @return bool
          */
         private function should_add_sticky_optin_notice() {
+            if ( $this->_anonymous_mode ||
+                ( $this->is_addon() && ( $this->_parent->_is_anonymous || $this->_parent->_anonymous_mode ) ) ) {
+                return false;
+            }
+
             if ( fs_is_network_admin() ) {
                 if ( ! $this->_is_network_active ) {
                     return false;

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -7235,7 +7235,7 @@
 
                         if ( $this->is_plugin_new_install() || $this->is_only_premium() ) {
                             if ( ! $this->_anonymous_mode &&
-                                 ( ! $this->is_addon() || ( ! $this->_parent->_is_anonymous && ! $this->_parent->_anonymous_mode ) ) ) {
+                                 ( ! $this->is_addon() || ! $this->_parent->is_anonymous() ) ) {
                                 // Show notice for new plugin installations.
                                 $this->_admin_notices->add(
                                     sprintf(
@@ -7286,8 +7286,7 @@
          * @return bool
          */
         private function should_add_sticky_optin_notice() {
-            if ( $this->_anonymous_mode ||
-                ( $this->is_addon() && ( $this->_parent->_is_anonymous || $this->_parent->_anonymous_mode ) ) ) {
+            if ( $this->is_addon() && $this->_parent->is_anonymous() ) {
                 return false;
             }
 

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.4.1';
+	$this_sdk_version = '2.4.1.0';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
[add-on] [opt-in] [notice] [bug-fix] As a first stage, if the user skipped the opt-in, don't show the admin notices asking to opt-in when activating an add-on.