### PR TITLE
Fix for php8

### DIFF
--- a/includes/class-fs-logger.php
+++ b/includes/class-fs-logger.php
@@ -142,7 +142,7 @@
 			return $this->_file_start;
 		}
 
-		private function _log( &$message, $type = 'log', $wrapper = false ) {
+		private function _log( &$message, $type, $wrapper = false ) {
 			if ( ! $this->is_on() ) {
 				return;
 			}


### PR DESCRIPTION
Unnecessary  optional arg ( all calls provide a value) on private function _log  line 145 of includes/class-fs-logger.php breaks PHP 8