### PR TITLE
Prevent potential PHP warnings when the fs_active_plugins option comes back with a non-object

### DIFF
--- a/start.php
+++ b/start.php
@@ -70,6 +70,11 @@
 		// Load all Freemius powered active plugins.
 		$fs_active_plugins = get_option( 'fs_active_plugins', new stdClass() );
 
+		// Prevent potential PHP 7.4+ warnings when the option came back with a non-object.
+		if ( ! is_object( $fs_active_plugins ) ) {
+			$fs_active_plugins = new stdClass();
+		}
+
 		if ( ! isset( $fs_active_plugins->plugins ) ) {
 			$fs_active_plugins->plugins = array();
 		}

--- a/start.php
+++ b/start.php
@@ -70,7 +70,7 @@
 		// Load all Freemius powered active plugins.
 		$fs_active_plugins = get_option( 'fs_active_plugins', new stdClass() );
 
-		// Prevent potential PHP 7.4+ warnings when the option came back with a non-object.
+		// Prevent potential PHP warnings when the option came back with a non-object.
 		if ( ! is_object( $fs_active_plugins ) ) {
 			$fs_active_plugins = new stdClass();
 		}


### PR DESCRIPTION
This is to address an issue a Pods user encountered here: https://wordpress.org/support/topic/error-when-activating-pods/#post-14295661