### PR TITLE
add to composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,5 +6,8 @@
     "license": "GPL-3.0-only",
     "require": {
         "php": ">=5.2"
-	}
+	},
+    "autoload": {
+        "files": ["./vendor/freemius/wordpress-sdk/start.php"]
+    }
 }


### PR DESCRIPTION
This PR adds the `start.php` file to composer's autoload function if the SDK is installed via composer. This simplifies the initiation of the SDK by not requiring the use of the `require`.