### PR TITLE
Feature/deactivation form

### DIFF
--- a/templates/forms/deactivation/form.php
+++ b/templates/forms/deactivation/form.php
@@ -284,9 +284,26 @@ HTML;
 			var _this = $(this);
 
 			if (_this.hasClass('allow-deactivate')) {
-				var $radio = $modal.find('input[type="radio"]:checked');
+				var
+                    $radio           = $modal.find('input[type="radio"]:checked'),
+                    isReasonSelected = (0 < $radio.length),
+                    userReason       = '';
 
-				if (0 === $radio.length) {
+				if ( isReasonSelected ) {
+                    var $selectedReason = $radio.parents('li:first'),
+                        $reasonInput = $selectedReason.find('textarea, input[type="text"]');
+
+                    if ( 0 < $reasonInput.length ) {
+                        userReason = $reasonInput.val().trim();
+                    }
+                }
+
+                if ( isOtherReasonSelected() && '' === userReason ) {
+                    // If the 'Other' is selected and a reason is not provided (aka it's empty), treat it as if a reason wasn't selected at all.
+                    isReasonSelected = false;
+                }
+
+                if ( ! isReasonSelected ) {
 				    if ( ! deleteThemeUpdateData ) {
                         // If no selected reason, just deactivate the plugin.
                         window.location.href = redirectLink;
@@ -311,18 +328,6 @@ HTML;
 
 					return;
 				}
-
-				var $selected_reason = $radio.parents('li:first'),
-				    $input = $selected_reason.find('textarea, input[type="text"]'),
-				    userReason = ( 0 !== $input.length ) ? $input.val().trim() : '';
-
-                if (isOtherReasonSelected() && ( '' === userReason )) {
-                    // If the reason is empty, just deactivate it without submitting the feedback.
-                    _parent.find('.fs-modal-footer .button').addClass('disabled');
-                    window.location.href = redirectLink;
-
-                    return;
-                }
 
 				$.ajax({
 					url       : ajaxurl,

--- a/templates/forms/deactivation/form.php
+++ b/templates/forms/deactivation/form.php
@@ -505,7 +505,7 @@ HTML;
             $deactivateButton.html('<?php echo
                 $fs->is_plugin() ?
                     $deactivate_text :
-                    fs_text_inline('Switch', 'switch', $slug)
+                    sprintf( $activate_x_text, $theme_text )
             ?>');
         } else {
             $deactivateButton.html('<?php echo esc_js( $submit_deactivate_text ) ?>');

--- a/templates/forms/deactivation/form.php
+++ b/templates/forms/deactivation/form.php
@@ -494,12 +494,13 @@ HTML;
             return;
         }
 
-        $user_reason       = $modal.find('.reason-input input');
-        $deactivate_button = $modal.find('.button-deactivate');
+        var
+            $userReason       = $modal.find('.reason-input input'),
+            $deactivateButton = $modal.find('.button-deactivate');
 
-	    if (0 === $user_reason.val().trim().length) {
-	        // If the reason is empty, just change the text to 'Deactivate'(plugin) or 'Switch'(theme).
-            $deactivate_button.html('<?php echo
+	    if (0 === $userReason.val().trim().length) {
+	        // If the reason is empty, just change the text to 'Deactivate' (plugin) or 'Activate themeX' (theme).
+            $deactivateButton.html('<?php echo
                 $fs->is_plugin() ?
                     $deactivate_text :
                     fs_text_inline('Switch', 'switch', $slug)

--- a/templates/forms/deactivation/form.php
+++ b/templates/forms/deactivation/form.php
@@ -303,6 +303,8 @@ HTML;
                     isReasonSelected = false;
                 }
 
+                _parent.find( '.fs-modal-footer .button' ).addClass( 'disabled' );
+
                 if ( ! isReasonSelected ) {
 				    if ( ! deleteThemeUpdateData ) {
                         // If no selected reason, just deactivate the plugin.
@@ -317,7 +319,6 @@ HTML;
                                 module_id: '<?php echo $fs->get_id() ?>'
                             },
                             beforeSend: function() {
-                                _parent.find( '.fs-modal-footer .button' ).addClass( 'disabled' );
                                 _parent.find( '.fs-modal-footer .button-deactivate' ).text( '<?php echo esc_js( fs_text_inline( 'Processing', 'processing', $slug ) ) ?>...' );
                             },
                             complete  : function() {
@@ -341,7 +342,6 @@ HTML;
 						is_anonymous: isAnonymousFeedback()
 					},
 					beforeSend: function () {
-						_parent.find('.fs-modal-footer .button').addClass('disabled');
 						_parent.find('.fs-modal-footer .button-deactivate').text('<?php echo esc_js( fs_text_inline( 'Processing', 'processing', $slug ) ) ?>...');
 					},
 					complete  : function () {

--- a/templates/forms/deactivation/form.php
+++ b/templates/forms/deactivation/form.php
@@ -301,7 +301,7 @@ HTML;
                             },
                             beforeSend: function() {
                                 _parent.find( '.fs-modal-footer .button' ).addClass( 'disabled' );
-                                _parent.find( '.fs-modal-footer .button-secondary' ).text( 'Processing...' );
+                                _parent.find( '.fs-modal-footer .button-deactivate' ).text( '<?php echo esc_js( fs_text_inline( 'Processing', 'processing', $slug ) ) ?>...' );
                             },
                             complete  : function() {
                                 window.location.href = redirectLink;
@@ -329,7 +329,7 @@ HTML;
 					},
 					beforeSend: function () {
 						_parent.find('.fs-modal-footer .button').addClass('disabled');
-						_parent.find('.fs-modal-footer .button-secondary').text('Processing...');
+						_parent.find('.fs-modal-footer .button-deactivate').text('<?php echo esc_js( fs_text_inline( 'Processing', 'processing', $slug ) ) ?>...');
 					},
 					complete  : function () {
 						// Do not show the dialog box, deactivate the plugin.

--- a/templates/forms/deactivation/form.php
+++ b/templates/forms/deactivation/form.php
@@ -241,9 +241,10 @@ HTML;
 			 * to change the message color back to default.
 			 */
 			if (reason.length > 0) {
-				$('.message').removeClass('error-message');
-				enableDeactivateButton();
-			}
+                $('.message').removeClass('error-message');
+            }
+
+            changeDeactivateButtonText();
 		});
 
 		$modal.on('blur', '.reason-input input', function () {
@@ -260,8 +261,8 @@ HTML;
 				 */
 				if (0 === $userReason.val().trim().length) {
 					$('.message').addClass('error-message');
-					disableDeactivateButton();
-				}
+                    changeDeactivateButtonText();
+                }
 			}, 150);
 		});
 
@@ -307,10 +308,6 @@ HTML;
 				var $selected_reason = $radio.parents('li:first'),
 				    $input = $selected_reason.find('textarea, input[type="text"]'),
 				    userReason = ( 0 !== $input.length ) ? $input.val().trim() : '';
-
-				if (isOtherReasonSelected() && ( '' === userReason )) {
-					return;
-				}
 
 				$.ajax({
 					url       : ajaxurl,
@@ -372,8 +369,6 @@ HTML;
 					sprintf( $activate_x_text, $theme_text )
 			) ) ?>');
 
-			enableDeactivateButton();
-
 			if ( _parent.hasClass( 'has-internal-message' ) ) {
 				_parent.find( '.internal-message' ).show();
 			}
@@ -388,8 +383,8 @@ HTML;
 
 				if (isOtherReasonSelected()) {
 					showMessage('<?php echo esc_js( fs_text_inline( 'Kindly tell us the reason so we can improve.', 'ask-for-reason-message' , $slug ) ); ?>');
-					disableDeactivateButton();
-				}
+                    changeDeactivateButtonText();
+                }
 			}
 		});
 
@@ -453,8 +448,6 @@ HTML;
 	function resetModal() {
 		selectedReasonID = false;
 
-		enableDeactivateButton();
-
 		// Uncheck all radio buttons.
 		$modal.find('input[type="radio"]').prop('checked', false);
 
@@ -491,13 +484,35 @@ HTML;
 		$modal.find('.message').text(message).show();
 	}
 
-	function enableDeactivateButton() {
-		$modal.find('.button-deactivate').removeClass('disabled');
-	}
+    /**
+     * @author Xiaheng Chen (@xhchen)
+     *
+     * @since 2.4.2
+     */
+	function changeDeactivateButtonText() {
+        if ( ! isOtherReasonSelected()) {
+            return;
+        }
 
-	function disableDeactivateButton() {
-		$modal.find('.button-deactivate').addClass('disabled');
-	}
+        $user_reason       = $modal.find('.reason-input input');
+        $deactivate_button = $modal.find('.button-deactivate');
+
+	    if (0 === $user_reason.val().trim().length) {
+	        // If the reason is empty, just change the text to 'Deactivate'(plugin) or 'Switch'(theme).
+            $deactivate_button.html('<?php echo
+                $fs->is_plugin() ?
+                    $deactivate_text :
+                    fs_text_inline('Switch', 'switch', $slug)
+            ?>');
+        } else {
+            $deactivate_button.html('<?php echo esc_js(sprintf(
+                fs_text_inline('Submit & %s', 'deactivation-modal-button-submit', $slug),
+                $fs->is_plugin() ?
+                    $deactivate_text :
+                    sprintf($activate_x_text, $theme_text)
+            )) ?>');
+        }
+    }
 
 	function showPanel(panelType) {
         $modal.find( '.fs-modal-panel' ).removeClass( 'active' );

--- a/templates/forms/deactivation/form.php
+++ b/templates/forms/deactivation/form.php
@@ -316,6 +316,14 @@ HTML;
 				    $input = $selected_reason.find('textarea, input[type="text"]'),
 				    userReason = ( 0 !== $input.length ) ? $input.val().trim() : '';
 
+                if (isOtherReasonSelected() && ( '' === userReason )) {
+                    // If the reason is empty, just deactivate it without submitting the feedback.
+                    _parent.find('.fs-modal-footer .button').addClass('disabled');
+                    window.location.href = redirectLink;
+
+                    return;
+                }
+
 				$.ajax({
 					url       : ajaxurl,
 					method    : 'POST',

--- a/templates/forms/deactivation/form.php
+++ b/templates/forms/deactivation/form.php
@@ -71,6 +71,13 @@ HTML;
 	$theme_text      = fs_text_inline( 'Theme', 'theme', $slug );
 	$activate_x_text = fs_text_inline( 'Activate %s', 'activate-x', $slug );
 
+    $submit_deactivate_text = sprintf(
+        fs_text_inline( 'Submit & %s', 'deactivation-modal-button-submit', $slug ),
+        $fs->is_plugin() ?
+            $deactivate_text :
+            sprintf( $activate_x_text, $theme_text )
+    );
+
 	fs_enqueue_local_style( 'fs_dialog_boxes', '/admin/dialog-boxes.css' );
 
     if ( ! empty( $subscription_cancellation_dialog_box_template_params ) ) {
@@ -362,12 +369,7 @@ HTML;
 
 			$modal.find('.reason-input').remove();
 			$modal.find( '.internal-message' ).hide();
-			$modal.find('.button-deactivate').html('<?php echo esc_js( sprintf(
-				fs_text_inline( 'Submit & %s', 'deactivation-modal-button-submit' , $slug ),
-				$fs->is_plugin() ?
-					$deactivate_text :
-					sprintf( $activate_x_text, $theme_text )
-			) ) ?>');
+			$modal.find('.button-deactivate').html('<?php echo esc_js( $submit_deactivate_text ) ?>');
 
 			if ( _parent.hasClass( 'has-internal-message' ) ) {
 				_parent.find( '.internal-message' ).show();
@@ -506,12 +508,7 @@ HTML;
                     fs_text_inline('Switch', 'switch', $slug)
             ?>');
         } else {
-            $deactivate_button.html('<?php echo esc_js(sprintf(
-                fs_text_inline('Submit & %s', 'deactivation-modal-button-submit', $slug),
-                $fs->is_plugin() ?
-                    $deactivate_text :
-                    sprintf($activate_x_text, $theme_text)
-            )) ?>');
+            $deactivateButton.html('<?php echo esc_js( $submit_deactivate_text ) ?>');
         }
     }
 


### PR DESCRIPTION
[deactivation-form] [ux] When a user chooses the `Other` option, enabled the submit button even though the reason input is empty. Also, if the reason is empty, change it to `Deactivate`.