### PR TITLE
$this->_parent->is_anonymous() throwing error.

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -23429,6 +23429,7 @@
             if (
                 $this->is_addon() &&
                 ! $this->is_only_premium() &&
+		is_object( $this->_parent ) &&
                 $this->_parent->is_anonymous()
             ) {
                 return;


### PR DESCRIPTION
It appears that `$this->_parent` can contain either an object or a boolean.
This should resolve the error by checking that it's an object before attempting to use the method `->is_anonymous()`.

It looks like `$this->_parent` is used in other places in this class.
Unknown if the `boolean` vs. `object` detail effects any other functionality.

Error attempting to be resolved:
```
Error Details
=============
An error of type E_ERROR was caused in line 23432 of the file /home/ekhulnac/public_html/destra/plugins/pods/vendor/freemius/wordpress-sdk/includes/class-freemius.php. Error message: Uncaught Error: Call to a member function is_anonymous() on bool in /home/ekhulnac/public_html/destra/plugins/pods/vendor/freemius/wordpress-sdk/includes/class-freemius.php:23432
Stack trace:
#0 /home/ekhulnac/public_html/destra/plugins/pods/vendor/freemius/wordpress-sdk/includes/class-freemius.php(2051): Freemius->_add_tracking_links()
#1 /home/ekhulnac/public_html/wp-includes/class-wp-hook.php(303): Freemius->_hook_action_links_and_register_account_hooks('')
#2 /home/ekhulnac/public_html/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters(NULL, Array)
#3 /home/ekhulnac/public_html/wp-includes/plugin.php(470): WP_Hook->do_action(Array)
#4 /home/ekhulnac/public_html/wp-admin/admin.php(175): do_action('admin_init')
#5 /home/ekhulnac/public_html/wp-admin/plugins.php(10): require_once('/home/ekhulnac/...')
#6 {main}
```

Unknown if related: It looks like the person reporting this error has changed has changed `wp-content` to `destra`.