### PR TITLE
[bugfix] prevent fatal error on plugin activation when SECURE_AUTH_KEY is missing

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -4047,7 +4047,7 @@
             if ( empty( $unique_id ) || ! is_string( $unique_id ) ) {
                 $key = fs_strip_url_protocol( get_site_url( $blog_id ) );
 
-                $secure_auth = SECURE_AUTH_KEY;
+                $secure_auth = defined( 'SECURE_AUTH_KEY' ) ? SECURE_AUTH_KEY : '';
                 if ( empty( $secure_auth ) ||
                      false !== strpos( $secure_auth, ' ' ) ||
                      'put your unique phrase here' === $secure_auth


### PR DESCRIPTION
This prevents a fatal error when a user tries to activate the plugin and the SECURE_AUTH_KEY is missing in wp-config.php