### PR TITLE
Feature/view details issue for premium only non add-on plugin fix

### DIFF
--- a/includes/class-fs-plugin-updater.php
+++ b/includes/class-fs-plugin-updater.php
@@ -1080,7 +1080,7 @@ if ( !isset($info->error) ) {
                 $this->_fs->get_plugin_version();
 
             // Get plugin's newest update.
-            $new_version = $this->get_latest_download_details( $is_addon ? $addon->id : false, $plugin_version );
+            $new_version = $this->get_latest_download_details( $is_addon ? $addon->id : false );
 
             if ( ! is_object( $new_version ) || empty( $new_version->version ) ) {
                 $data->version = $plugin_version;


### PR DESCRIPTION
- [view-details] Removed `newer_than` parameter value to get the latest available details.