### PR TITLE
[php8.1] Silence the deprecation notices introduced in PHP 8.1

### DIFF
--- a/includes/managers/class-fs-key-value-storage.php
+++ b/includes/managers/class-fs-key-value-storage.php
@@ -298,6 +298,7 @@
 			return $this->get( $k, null );
 		}
 
+		#[ReturnTypeWillChange]
 		function offsetSet( $k, $v ) {
 			if ( is_null( $k ) ) {
 				throw new Exception( 'Can\'t append value to request params.' );
@@ -306,14 +307,17 @@
 			}
 		}
 
+		#[ReturnTypeWillChange]
 		function offsetExists( $k ) {
 			return array_key_exists( $k, $this->_data );
 		}
 
+		#[ReturnTypeWillChange]
 		function offsetUnset( $k ) {
 			unset( $this->$k );
 		}
 
+		#[ReturnTypeWillChange]
 		function offsetGet( $k ) {
 			return $this->get( $k, null );
 		}
@@ -325,6 +329,7 @@
 		 * @link http://php.net/manual/en/iterator.current.php
 		 * @return mixed Can return any type.
 		 */
+		#[ReturnTypeWillChange]
 		public function current() {
 			return current( $this->_data );
 		}
@@ -336,6 +341,7 @@
 		 * @link http://php.net/manual/en/iterator.next.php
 		 * @return void Any returned value is ignored.
 		 */
+		#[ReturnTypeWillChange]
 		public function next() {
 			next( $this->_data );
 		}
@@ -347,6 +353,7 @@
 		 * @link http://php.net/manual/en/iterator.key.php
 		 * @return mixed scalar on success, or null on failure.
 		 */
+		#[ReturnTypeWillChange]
 		public function key() {
 			return key( $this->_data );
 		}
@@ -359,6 +366,7 @@
 		 * @return boolean The return value will be casted to boolean and then evaluated.
 		 *       Returns true on success or false on failure.
 		 */
+		#[ReturnTypeWillChange]
 		public function valid() {
 			$key = key( $this->_data );
 
@@ -372,6 +380,7 @@
 		 * @link http://php.net/manual/en/iterator.rewind.php
 		 * @return void Any returned value is ignored.
 		 */
+		#[ReturnTypeWillChange]
 		public function rewind() {
 			reset( $this->_data );
 		}
@@ -386,6 +395,7 @@
 		 *       <p>
 		 *       The return value is cast to an integer.
 		 */
+		#[ReturnTypeWillChange]
 		public function count() {
 			return count( $this->_data );
 		}


### PR DESCRIPTION
There are several "PHP Deprecated" warnings in the `FS_Key_Value_Storage` class due to incompatibility with the `ArrayAccess` interface. These warnings appeared as of PHP 8.1: https://make.wordpress.org/core/2022/01/10/wordpress-5-9-and-php-8-0-8-1/#php-8-1-return-type-enforcement-and-new-returntypewillchange-attribute