### PR TITLE
feature/optin skip

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -12908,7 +12908,21 @@
                 } else if ( $is_whitelabeled_flag ) {
                     $is_whitelabeled = true;
                 } else {
-                    $addon_ids        = $this->get_updated_account_addons();
+                    if ( $this->is_registered() || $this->is_premium() ) {
+                        $addon_ids = $this->get_updated_account_addons();
+                    } else {
+                        $addons = self::get_all_addons();
+
+                        $plugin_addons = isset( $addons[ $this->_plugin->id ] ) ?
+                            $addons[ $this->_plugin->id ] :
+                            array();
+
+                        $addon_ids = array();
+                        foreach ( $plugin_addons as $addon ) {
+                            $addon_ids[] = $addon->id;
+                        }
+                    }
+
                     $installed_addons = $this->get_installed_addons();
                     foreach ( $installed_addons as $fs_addon ) {
                         $addon_ids[] = $fs_addon->get_id();


### PR DESCRIPTION
[optin-skip] [addons] [bug-fix] If the user is not opted-in and runs a free version of the plugin, rely on the addon's data available in the WP DB instead of getting the updated add-on IDs collection from the API.