### PR TITLE
Send Affiliate requests to the Bundle if the developer has used a bundle_id in dynamic_init

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -23303,6 +23303,7 @@
 
             if ( $is_bundle_context ) {
                 $plugin_title = $this->plugin_affiliate_terms->plugin_title;
+
                 // Add the suffix "Bundle" only if the word is not present in the title itself.
                 if ( false === mb_stripos( $plugin_title, fs_text_inline( 'Bundle', 'bundle' ) ) ) {
                     $plugin_title = $this->apply_filters(

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -14980,7 +14980,7 @@
                             var_export( $next_page, true )
                     );
                 } else if ( $this->is_pending_activation() ) {
-                    self::shoot_ajax_failure( $this->get_text_inline( 'Account is pending activation.', 'account-is-pending-activation' ) );
+                    self::shoot_ajax_failure( $this->get_text_inline( 'Account is pending activation. Please check your email and click the link to activate your account and then submit the affiliate form again.', 'account-is-pending-activation' ) );
                 }
             }
 

--- a/includes/entities/class-fs-affiliate-terms.php
+++ b/includes/entities/class-fs-affiliate-terms.php
@@ -84,6 +84,10 @@
          * @var bool If `true`, allow referrals from any site.
          */
         public $is_any_site_allowed;
+        /**
+         * @var string $plugin_title Title of the plugin. This is used in case we are showing affiliate form for a Bundle instead of the `plugin` in context.
+         */
+        public $plugin_title;
 
         #endregion Properties
 

--- a/includes/i18n.php
+++ b/includes/i18n.php
@@ -552,6 +552,12 @@
 		'secure-x-page-header' => _fs_text( 'Secure HTTPS %s page, running from an external domain' ),
 		'pci-compliant'        => _fs_text( 'PCI compliant' ),
 		'view-paid-features'   => _fs_text( 'View paid features' ),
+
+        #--------------------------------------------------------------------------------
+        #region Bundle
+        #--------------------------------------------------------------------------------
+        'bundle'        => _fs_text( 'Bundle' ),
+        'bundle-suffix' => _fs_text( ' Bundle' ),
 	);
 
 	/**

--- a/includes/i18n.php
+++ b/includes/i18n.php
@@ -143,7 +143,7 @@
         'paypal-email-address-is-required'   => _fs_text( 'PayPal email address is required.' ),
         'processing'                         => _fs_text( 'Processing...' ),
         'non-expiring'                       => _fs_text( 'Non-expiring' ),
-        'account-is-pending-activation'      => _fs_text( 'Account is pending activation.' ),
+        'account-is-pending-activation'      => _fs_text( 'Account is pending activation. Please check your email and click the link to activate your account and then submit the affiliate form again' ),
         #endregion Affiliation
 
 		#region Account

--- a/includes/i18n.php
+++ b/includes/i18n.php
@@ -143,7 +143,7 @@
         'paypal-email-address-is-required'   => _fs_text( 'PayPal email address is required.' ),
         'processing'                         => _fs_text( 'Processing...' ),
         'non-expiring'                       => _fs_text( 'Non-expiring' ),
-        'account-is-pending-activation'      => _fs_text( 'Account is pending activation. Please check your email and click the link to activate your account and then submit the affiliate form again.' ),
+        'account-is-pending-activation'      => _fs_text( 'Account is pending activation.' ),
         #endregion Affiliation
 
 		#region Account
@@ -552,12 +552,6 @@
 		'secure-x-page-header' => _fs_text( 'Secure HTTPS %s page, running from an external domain' ),
 		'pci-compliant'        => _fs_text( 'PCI compliant' ),
 		'view-paid-features'   => _fs_text( 'View paid features' ),
-
-        #--------------------------------------------------------------------------------
-        #region Bundle
-        #--------------------------------------------------------------------------------
-        'bundle'        => _fs_text( 'Bundle' ),
-        'bundle-suffix' => _fs_text( ' Bundle' ),
 	);
 
 	/**

--- a/includes/i18n.php
+++ b/includes/i18n.php
@@ -143,7 +143,7 @@
         'paypal-email-address-is-required'   => _fs_text( 'PayPal email address is required.' ),
         'processing'                         => _fs_text( 'Processing...' ),
         'non-expiring'                       => _fs_text( 'Non-expiring' ),
-        'account-is-pending-activation'      => _fs_text( 'Account is pending activation. Please check your email and click the link to activate your account and then submit the affiliate form again' ),
+        'account-is-pending-activation'      => _fs_text( 'Account is pending activation. Please check your email and click the link to activate your account and then submit the affiliate form again.' ),
         #endregion Affiliation
 
 		#region Account

--- a/templates/forms/affiliation.php
+++ b/templates/forms/affiliation.php
@@ -13,8 +13,10 @@
     /**
      * @var array    $VARS
      * @var Freemius $fs
+     * @var string   $plugin_title
      */
-    $fs = freemius( $VARS['id'] );
+    $fs           = freemius( $VARS['id'] );
+    $plugin_title = $VARS['plugin_title'];
 
     $slug = $fs->get_slug();
 
@@ -22,7 +24,6 @@
     $affiliate       = $fs->get_affiliate();
     $affiliate_terms = $fs->get_affiliate_terms();
 
-    $plugin_title = $fs->get_plugin_title();
     $module_type  = $fs->is_plugin() ?
         WP_FS__MODULE_TYPE_PLUGIN :
         WP_FS__MODULE_TYPE_THEME;

--- a/templates/forms/affiliation.php
+++ b/templates/forms/affiliation.php
@@ -507,4 +507,3 @@
         'module_version' => $fs->get_plugin_version(),
     );
     fs_require_template( 'powered-by.php', $params );
-?>

--- a/templates/forms/affiliation.php
+++ b/templates/forms/affiliation.php
@@ -46,7 +46,7 @@
     $promotion_method_mobile_apps  = false;
     $statistics_information        = false;
     $promotion_method_description  = false;
-    $members_dashboard_login_url   = 'https://members.freemius.com/login/';
+    $members_dashboard_login_url   = 'https://users.freemius.com/login';
 
     $affiliate_application_data = $fs->get_affiliate_application_data();
 


### PR DESCRIPTION
Right now, we are sending affiliate requests to the main plugin installed through the bundle. Under the assumption that the developer would like to promote a Bundle when the `bundle_id` is set, we _should_ send the affiliate request to the bundle instead. This PR does that.

Additionally, I figured we could improve the application flow a little as we are already in the context.

---

## Improve error message shown to non-opted users

When a plugin/theme user is applying to become an affiliate, if they haven't opted in, they we do opt them, but we do not track.

However, the opt-in process does require consent from the email sent. Due to this, when a non-opted user tries to submit the affiliate form, it fails and just returns a message saying "Account is pending activation".

From a user's perspective who hasn't opted in (skipped during plugin activation), that does not give any instruction as to what to do next. So I improved the error message to give clear steps one needs to perform.

On the first step, it shows

> Account is pending activation. Please check your email and click the link to activate your account and then submit the affiliate form again.

<img width="1238" alt="Screen Shot 2022-03-09 at 1 07 01 PM" src="https://user-images.githubusercontent.com/1623381/157397592-a582f6c6-57e1-41bc-93ce-ae0b44f9428f.png">

On the second step, the user goes to the email and clicks to opt-in (giving consent).

<img width="902" alt="Screen Shot 2022-03-09 at 1 07 17 PM" src="https://user-images.githubusercontent.com/1623381/157397533-7be93c6c-e534-41f8-a773-7d0a979fe1d0.png">

On the third step, (after clicking the link), it takes to the Account page, stating that the account was activated.

<img width="936" alt="Screen Shot 2022-03-09 at 1 07 33 PM" src="https://user-images.githubusercontent.com/1623381/157397741-88c4b164-a3a3-4838-9797-993f44ffa3d8.png">

Finally, on the last step, the user submits the affiliate form again and a proper message is shown.

<img width="1178" alt="Screen Shot 2022-03-09 at 1 08 13 PM" src="https://user-images.githubusercontent.com/1623381/157396959-abe789f5-1a06-42ef-b356-ae2131bd1c8b.png">

---

## Fix the link to our User Dashboard

Instead of linking to `members.freemius.com` we link to `users.freemius.com`. I left the trailing slash `/` out from the URL intentionally because that is how the website works.

<img width="1021" alt="Screen Shot 2022-03-09 at 1 12 44 PM" src="https://user-images.githubusercontent.com/1623381/157397079-1c8c2739-e6f6-4e4a-b58d-968e36afe4cf.png">



