### PR TITLE
[sync] Fixed an issue with the manual sync mechanism that occurs when…

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -5185,6 +5185,9 @@
                      * Check if requested for manual blocking background sync.
                      */
                     if ( fs_request_has( 'background_sync' ) ) {
+                        self::require_pluggable_essentials();
+                        self::wp_cookie_constants();
+
                         $this->run_manual_sync();
                     }
                 }
@@ -7145,8 +7148,6 @@
          * @since  1.1.7.3
          */
         private function run_manual_sync() {
-            self::require_pluggable_essentials();
-
             if ( ! $this->is_user_admin() ) {
                 return;
             }

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.5.0.3';
+	$this_sdk_version = '2.5.0.4';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
… it's run before the relevant core WP files are loaded or before the relevant core WP constants are defined.