### PR TITLE
Update class-fs-admin-menu-manager.php

### DIFF
--- a/includes/managers/class-fs-admin-menu-manager.php
+++ b/includes/managers/class-fs-admin-menu-manager.php
@@ -703,11 +703,15 @@
                 $menu['parent_slug'] :
                 'admin.php';
 
+            $parent_query = isset( $menu['menu'][2]) ?
+				( false === strpos( $parent_slug, '?' ) ? '?' : '&' ) .
+				'page=' .
+				$menu['menu'][2]:
+				'';
+
             return admin_url(
                 $parent_slug .
-                ( false === strpos( $parent_slug, '?' ) ? '?' : '&' ) .
-                'page=' .
-                $menu['menu'][2]
+                $parent_query
             );
 		}
 


### PR DESCRIPTION
Remove  PHP warning when both top level and sub menu return false and so $menu['menu'][2] is not defined