### PR TITLE
[ajax-requests] [update] [major] Only Freemius' AJAX calls now explic…

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -1500,46 +1500,6 @@
         }
 
         /**
-         * Add special parameter to WP admin AJAX calls so when we
-         * process AJAX calls we can identify its source properly.
-         *
-         * @author Leo Fajardo (@leorw)
-         * @since  2.0.0
-         */
-        static function _enrich_ajax_url() {
-            $admin_param = is_network_admin() ?
-                '_fs_network_admin' :
-                '_fs_blog_admin';
-            ?>
-            <script type="text/javascript">
-                (function ($) {
-                    $(document).ajaxSend(function (event, jqxhr, settings) {
-                        if (settings.url &&
-                            -1 < settings.url.indexOf('admin-ajax.php') &&
-                            ! ( settings.url.indexOf( '<?php echo $admin_param ?>' ) > 0 )
-                        ) {
-                            if (
-                                'string' === typeof settings.data &&
-                                settings.data.indexOf( 'action=heartbeat' ) > 0
-                            ) {
-                                return;
-                            }
-
-                            if (settings.url.indexOf('?') > 0) {
-                                settings.url += '&';
-                            } else {
-                                settings.url += '?';
-                            }
-
-                            settings.url += '<?php echo $admin_param ?>=true';
-                        }
-                    });
-                })(jQuery);
-            </script>
-            <?php
-        }
-
-        /**
          * Opens the support forum subemenu item in a new browser page.
          *
          * @author Vova Feldman (@svovaf)
@@ -3591,7 +3551,6 @@
             $clone_manager = FS_Clone_Manager::instance();
             add_action( 'init', array( $clone_manager, '_init' ) );
 
-            add_action( 'admin_footer', array( 'Freemius', '_enrich_ajax_url' ) );
             add_action( 'admin_footer', array( 'Freemius', '_open_support_forum_in_new_page' ) );
 
             if ( self::is_plugins_page() || self::is_themes_page() ) {
@@ -19938,6 +19897,33 @@
             }
 
             wp_send_json( $result );
+        }
+
+        /**
+         * Returns an AJAX URL with a special extra param to indicate whether the request was triggered from the network admin or blog admin.
+         *
+         * @author Vova Feldman (@svovaf)
+         * @since  2.5.1
+         *
+         * @param string $wrap_with By default, returns the AJAX URL wrapped with single quotes.
+         *
+         * @return string
+         */
+        static function ajax_url( $wrap_with = "'") {
+            $path = 'admin-ajax.php';
+
+            if ( fs_is_network_admin() ) {
+                $url        = network_admin_url( $path );
+                $param_name = '_fs_network_admin';
+            } else {
+                $url        = admin_url( $path );
+                $param_name = '_fs_blog_admin';
+            }
+
+            $url .= ( false === strpos( $url, '?' ) ) ? '?' : '&';
+            $url .= "{$param_name}=true";
+
+            return "{$wrap_with}{$url}{$wrap_with}";
         }
 
         /**

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.5.0.13';
+	$this_sdk_version = '2.5.0.16';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/templates/account.php
+++ b/templates/account.php
@@ -948,7 +948,7 @@
 
                 if ( ! isChecked || confirm( '<?php echo $confirmation_message ?>' ) ) {
                     $.ajax( {
-                        url   : ajaxurl,
+                        url   : <?php echo Freemius::ajax_url() ?>,
                         method: 'POST',
                         data  : {
                             action   : '<?php echo $fs->get_ajax_action( 'set_beta_mode' ) ?>',
@@ -1091,7 +1091,7 @@
                 var $toggleLink = $( this );
 
                 $.ajax( {
-                    url   : ajaxurl,
+                    url   : <?php echo Freemius::ajax_url() ?>,
                     method: 'POST',
                     data  : {
                         action   : '<?php echo $fs->get_ajax_action( 'toggle_whitelabel_mode' ) ?>',

--- a/templates/account/billing.php
+++ b/templates/account/billing.php
@@ -377,7 +377,7 @@
 				});
 
 				$.ajax({
-					url    : ajaxurl,
+					url    : <?php echo Freemius::ajax_url() ?>,
 					method : 'POST',
 					data   : {
 						action   : '<?php echo $fs->get_ajax_action( 'update_billing' ) ?>',

--- a/templates/auto-installation.php
+++ b/templates/auto-installation.php
@@ -164,7 +164,7 @@
 				}
 
 				$.ajax({
-					url    : ajaxurl,
+					url    : <?php echo Freemius::ajax_url() ?>,
 					method : 'POST',
 					data   : data,
 					success: function (resultObj) {

--- a/templates/connect.php
+++ b/templates/connect.php
@@ -851,7 +851,7 @@
 					 * @since 1.2.1.5
 					 */
 					$.ajax({
-						url    : ajaxurl,
+						url    : <?php echo Freemius::ajax_url() ?>,
 						method : 'POST',
 						data   : data,
 						success: function (result) {
@@ -1036,7 +1036,7 @@
                         $primaryCta.html('<?php fs_esc_js_echo_inline( 'Please wait', 'please-wait', $slug ) ?>...');
 
                         $.ajax({
-                            url    : ajaxurl,
+                            url    : <?php echo Freemius::ajax_url() ?>,
                             method : 'POST',
                             data   : {
                                 action     : '<?php echo $fs->get_ajax_action( 'fetch_is_marketing_required_flag_value' ) ?>',

--- a/templates/debug.php
+++ b/templates/debug.php
@@ -35,7 +35,7 @@
                         .toggleClass( 'fs-on' )
                         .toggleClass( 'fs-off' );
 
-                    $.post( ajaxurl, {
+                    $.post( <?php echo Freemius::ajax_url() ?>, {
                         action: 'fs_toggle_debug_mode',
                         // As such we don't need to use `wp_json_encode` method but using it to follow wp.org guideline.
                         _wpnonce   : <?php echo wp_json_encode( wp_create_nonce( 'fs_toggle_debug_mode' ) ); ?>,
@@ -121,7 +121,7 @@
             var optionName = prompt('Please enter the option name:');
 
             if (optionName) {
-                $.post(ajaxurl, {
+                $.post(<?php echo Freemius::ajax_url() ?>, {
                     action     : 'fs_get_db_option',
                     // As such we don't need to use `wp_json_encode` method but using it to follow wp.org guideline.
                     _wpnonce   : <?php echo wp_json_encode( wp_create_nonce( 'fs_get_db_option' ) ); ?>,
@@ -142,7 +142,7 @@
                 var optionValue = prompt('Please enter the option value:');
 
                 if (optionValue) {
-                    $.post(ajaxurl, {
+                    $.post(<?php echo Freemius::ajax_url() ?>, {
                         action      : 'fs_set_db_option',
                         // As such we don't need to use `wp_json_encode` method but using it to follow wp.org guideline.
                         _wpnonce    : <?php echo wp_json_encode( wp_create_nonce( 'fs_set_db_option' ) ); ?>,
@@ -744,7 +744,7 @@
                     offset = 0;
                 }
 
-                $.post(ajaxurl, {
+                $.post(<?php echo Freemius::ajax_url() ?>, {
                     action : 'fs_get_debug_log',
                     // As such we don't need to use `wp_json_encode` method but using it to follow wp.org guideline.
                     _wpnonce : <?php echo wp_json_encode( wp_create_nonce( 'fs_get_debug_log' ) ); ?>,

--- a/templates/firewall-issues-js.php
+++ b/templates/firewall-issues-js.php
@@ -49,7 +49,7 @@
 			$( this ).css({'cursor': 'wait'});
 
 			// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
-			$.post( ajaxurl, data, function( response ) {
+			$.post( <?php echo Freemius::ajax_url() ?>, data, function( response ) {
 				if ( 1 == response ) {
 					// Refresh page on success.
 					location.reload();

--- a/templates/firewall-issues-js.php
+++ b/templates/firewall-issues-js.php
@@ -48,7 +48,6 @@
 
 			$( this ).css({'cursor': 'wait'});
 
-			// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
 			$.post( <?php echo Freemius::ajax_url() ?>, data, function( response ) {
 				if ( 1 == response ) {
 					// Refresh page on success.

--- a/templates/forms/affiliation.php
+++ b/templates/forms/affiliation.php
@@ -366,7 +366,7 @@
                     }
 
                     $.ajax({
-                        url       : ajaxurl,
+                        url       : <?php echo Freemius::ajax_url() ?>,
                         method    : 'POST',
                         data      : {
                             action   : '<?php echo $fs->get_ajax_action( 'submit_affiliate_application' ) ?>',

--- a/templates/forms/data-debug-mode.php
+++ b/templates/forms/data-debug-mode.php
@@ -140,7 +140,7 @@ HTML;
             };
 
             $.ajax( {
-                url       : ajaxurl,
+                url       : <?php echo Freemius::ajax_url() ?>,
                 method    : 'POST',
                 data      : data,
                 beforeSend: function () {

--- a/templates/forms/deactivation/form.php
+++ b/templates/forms/deactivation/form.php
@@ -180,7 +180,7 @@ HTML;
                 ?>
 
                 $.ajax({
-                    url       : ajaxurl,
+                    url       : <?php echo Freemius::ajax_url() ?>,
                     method    : 'POST',
                     data      : {
                         action   : '<?php echo $fs->get_ajax_action( 'cancel_subscription_or_trial' ) ?>',
@@ -347,7 +347,7 @@ HTML;
                         window.location.href = redirectLink;
                     } else {
                         $.ajax({
-                            url       : ajaxurl,
+                            url       : <?php echo Freemius::ajax_url() ?>,
                             method    : 'POST',
                             data      : {
                                 action   : '<?php echo $fs->get_ajax_action( 'delete_theme_update_data' ) ?>',
@@ -374,7 +374,7 @@ HTML;
                 }
 
 				$.ajax({
-					url       : ajaxurl,
+					url       : <?php echo Freemius::ajax_url() ?>,
 					method    : 'POST',
 					data      : {
 						action       : '<?php echo $fs->get_ajax_action( 'submit_uninstall_reason' ) ?>',

--- a/templates/forms/email-address-update.php
+++ b/templates/forms/email-address-update.php
@@ -185,7 +185,7 @@
             }
 
             $.ajax( {
-                url       : ajaxurl,
+                url       : <?php echo Freemius::ajax_url() ?>,
                 method    : 'POST',
                 data      : {
                     action       : '<?php echo $fs->get_ajax_action( 'update_email_address' ) ?>',

--- a/templates/forms/license-activation.php
+++ b/templates/forms/license-activation.php
@@ -369,7 +369,7 @@ HTML;
                 $activateLicenseButton.html( '<?php fs_esc_js_echo_inline( 'Please wait', 'please-wait', $slug ) ?>...' );
 
                 $.ajax( {
-                    url    : ajaxurl,
+                    url    : <?php echo Freemius::ajax_url() ?>,
                     method : 'POST',
                     data   : {
                         action     : '<?php echo $fs->get_ajax_action( 'fetch_is_marketing_required_flag_value' ) ?>',
@@ -634,7 +634,7 @@ HTML;
                 }
 
 				$.ajax({
-					url: ajaxurl,
+					url: <?php echo Freemius::ajax_url() ?>,
 					method: 'POST',
                     data: data,
 					beforeSend: function () {

--- a/templates/forms/optout.php
+++ b/templates/forms/optout.php
@@ -182,7 +182,7 @@
 			    var $actionLink = $( actionLinkSelector );
 
 				$.ajax({
-					url: ajaxurl,
+					url: <?php echo Freemius::ajax_url() ?>,
 					method: 'POST',
 					data: {
 						action   : ( 'stop_tracking' == action ?
@@ -246,7 +246,7 @@
                 $switchFeedback.html( '<i class="fs-ajax-spinner"></i>' );
 
                 $.ajax({
-                    url: ajaxurl,
+                    url: <?php echo Freemius::ajax_url() ?>,
                     method: 'POST',
                     data: {
                         action    : '<?php echo $fs->get_ajax_action( 'update_tracking_permission' ) ?>',

--- a/templates/forms/resend-key.php
+++ b/templates/forms/resend-key.php
@@ -145,7 +145,7 @@ HTML;
 					}
 
 					$.ajax({
-						url       : ajaxurl,
+						url       : <?php echo Freemius::ajax_url() ?>,
 						method    : 'POST',
 						data      : {
 							action     : '<?php echo $fs->get_ajax_action( 'resend_license_key' ) ?>',

--- a/templates/forms/trial-start.php
+++ b/templates/forms/trial-start.php
@@ -80,7 +80,7 @@ HTML;
 					var $button = $(this);
 
 					$.ajax({
-						url       : ajaxurl,
+						url       : <?php echo Freemius::ajax_url() ?>,
 						method    : 'POST',
 						data      : {
 							action   : '<?php echo $fs->get_ajax_action( 'start_trial' ) ?>',

--- a/templates/forms/user-change.php
+++ b/templates/forms/user-change.php
@@ -194,7 +194,7 @@ HTML;
                 disableUserChangeButton();
 
                 $.ajax( {
-                    url       : ajaxurl,
+                    url       : <?php echo Freemius::ajax_url() ?>,
                     method    : 'POST',
                     data      : {
                         action       : '<?php echo $fs->get_ajax_action( 'change_user' ) ?>',

--- a/templates/gdpr-optin-js.php
+++ b/templates/gdpr-optin-js.php
@@ -38,7 +38,7 @@
                 }
 
                 $.ajax({
-                    url       : ajaxurl + '?' + $.param({
+                    url       : <?php echo Freemius::ajax_url() ?> + '?' + $.param({
                         action   : '<?php echo $fs->get_ajax_action( 'gdpr_optin_action' ) ?>',
                         security : '<?php echo $fs->get_ajax_security( 'gdpr_optin_action' ) ?>',
                         module_id: '<?php echo $fs->get_id() ?>'

--- a/templates/sticky-admin-notice-js.php
+++ b/templates/sticky-admin-notice-js.php
@@ -29,7 +29,6 @@
 					message_id: id
 				};
 
-				// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
 				$.post( <?php echo Freemius::ajax_url() ?>, data, function( response ) {
 
 				});

--- a/templates/sticky-admin-notice-js.php
+++ b/templates/sticky-admin-notice-js.php
@@ -30,7 +30,7 @@
 				};
 
 				// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
-				$.post( ajaxurl, data, function( response ) {
+				$.post( <?php echo Freemius::ajax_url() ?>, data, function( response ) {
 
 				});
 

--- a/templates/tabs-capture-js.php
+++ b/templates/tabs-capture-js.php
@@ -45,7 +45,7 @@
 					var tabsHtml = $('.wrap .nav-tab-wrapper').clone().wrap('<div>').parent().html();
 
 					$.ajax({
-						url        : ajaxurl + '?' + $.param({
+						url        : <?php echo Freemius::ajax_url() ?> + '?' + $.param({
 							action   : '<?php echo $fs->get_ajax_action( 'store_tabs' ) ?>',
 							security : '<?php echo $fs->get_ajax_security( 'store_tabs' ) ?>',
 							module_id: '<?php echo $fs->get_id() ?>'


### PR DESCRIPTION
…itly include the necessary querystring params to determine if the request was triggered from the network or blog WP Admin. It replaces the previous mechanism that appended querystring params to all non-heartbeat AJAX requests, which was easier and more efficient to implement, but some users don't like it.