### PR TITLE
[tested-up-to] [enhancement] If the current WordPress version is a pa…

### DIFF
--- a/includes/class-fs-plugin-updater.php
+++ b/includes/class-fs-plugin-updater.php
@@ -417,7 +417,7 @@
 
             $themes_update = get_site_transient( 'update_themes' );
             if ( ! isset( $themes_update->response[ $theme_basename ] ) ||
-                empty( $themes_update->response[ $theme_basename ]['package'] )
+                 empty( $themes_update->response[ $theme_basename ]['package'] )
             ) {
                 return $prepared_themes;
             }
@@ -636,7 +636,7 @@
                     foreach ( $this->_translation_updates as $translation_update ) {
                         $lang = $translation_update['language'];
                         if ( ! isset( $current_plugin_translation_updates_map[ $lang ] ) ||
-                            version_compare( $translation_update['version'], $current_plugin_translation_updates_map[ $lang ]['version'], '>' )
+                             version_compare( $translation_update['version'], $current_plugin_translation_updates_map[ $lang ]['version'], '>' )
                         ) {
                             $current_plugin_translation_updates_map[ $lang ] = $translation_update;
                         }
@@ -665,7 +665,7 @@
             $update->new_version = $new_version->version;
             $update->url         = WP_FS__ADDRESS;
             $update->package     = $new_version->url;
-            $update->tested      = $new_version->tested_up_to_version;
+            $update->tested      = self::get_tested_wp_version( $new_version->tested_up_to_version );
             $update->requires    = $new_version->requires_platform_version;
 
             $icon = $this->_fs->get_local_icon_url();
@@ -808,9 +808,9 @@
             $basename = $this->_fs->get_plugin_basename();
 
             if ( ! is_object( $transient_data ) ||
-                ! isset( $transient_data->response ) ||
+                 ! isset( $transient_data->response ) ||
                  ! is_array( $transient_data->response ) ||
-                empty( $transient_data->response[ $basename ] )
+                 empty( $transient_data->response[ $basename ] )
             ) {
                 return;
             }
@@ -1148,7 +1148,26 @@ if ( !isset($info->error) ) {
                 }
             }
 
+            if ( ! empty( $data->tested ) ) {
+                $data->tested = self::get_tested_wp_version( $data->tested );
+            }
+
             return $data;
+        }
+
+        /**
+         * @since 2.5.3 If the current WordPress version is a patch of the tested version (e.g., 6.1.2 is a patch of 6.1), then override the tested version with the patch so developers won't need to release a new version just to bump the latest supported WP version.
+         *
+         * @param string $tested_up_to
+         *
+         * @return string
+         */
+        private static function get_tested_wp_version( $tested_up_to ) {
+            $current_wp_version = get_bloginfo( 'version' );
+
+            return fs_starts_with( $current_wp_version, $tested_up_to . '.' ) ?
+                $current_wp_version :
+                $tested_up_to;
         }
 
         /**


### PR DESCRIPTION
…tch of the "Tested up to" version (e.g., 6.1.2 is a patch of 6.1), then override it with the patch so developers won't need to release a new version just to bump the latest supported WP version patch.