### PR TITLE
[filters] [new] Introduced `'checkout_url'` and `'update_notice_checkout_url'` as filters for the checkout URL.

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -15283,7 +15283,11 @@
 
             return sprintf(
                 $this->get_text_inline( '%s to access version %s security & feature updates, and support.', 'x-for-updates-and-support' ),
-                sprintf( '<a href="%s">%s</a>', $url, $purchase_license_text ),
+                sprintf(
+                    '<a href="%s">%s</a>',
+                    $this->apply_filters( 'update_notice_checkout_url', $url ),
+                    $purchase_license_text
+                ),
                 $new_version
             );
         }
@@ -15353,7 +15357,7 @@
              */
             $params = array_merge( $params, $extra );
 
-            return $this->_get_admin_page_url( 'pricing', $params, $network );
+            return $this->apply_filters( 'checkout_url', $this->_get_admin_page_url( 'pricing', $params, $network ) );
         }
 
         /**


### PR DESCRIPTION
[filters] [new] Introduced `'checkout_url'` filter to optionally override the URL of the checkout across the entire SDK. And `'update_notice_checkout_url'` filter to specifically override the checkout URL shown in the admin notice when a license has expired.