### PR TITLE
Prepare Release 2.5.4

### DIFF
--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.5.4';
+	$this_sdk_version = '2.5.4.2';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
We use the internal SDK version as `2.5.4.2` and not `2.5.4` because in
one of the previous releases, we tagged it as `2.5.4.1` and it has been
out in the wild.
    
The next version would automatically simplify it.
