### PR TITLE
[api] [error-handling] When checking a response header, ensure that t…

### DIFF
--- a/includes/class-fs-api.php
+++ b/includes/class-fs-api.php
@@ -371,7 +371,7 @@
          * @param string $url
          * @param array  $remote_args
          *
-         * @return mixed
+         * @return array|WP_Error The response array or a WP_Error on failure.
          */
         static function remote_request( $url, $remote_args ) {
             if ( ! class_exists( 'Freemius_Api_WordPress' ) ) {

--- a/includes/class-fs-api.php
+++ b/includes/class-fs-api.php
@@ -386,8 +386,11 @@
             $response = wp_remote_request( $url, $remote_args );
 
             if (
-                empty( $response['headers'] ) ||
-                empty( $response['headers']['x-api-server'] )
+                is_array( $response ) &&
+                (
+                    empty( $response['headers'] ) ||
+                    empty( $response['headers']['x-api-server'] )
+                )
             ) {
                 // API is considered blocked if the response doesn't include the `x-api-server` header. When there's no error but this header doesn't exist, the response is usually not in the expected form (e.g., cannot be JSON-decoded).
                 $response = new WP_Error( 'api_blocked', htmlentities( $response['body'] ) );

--- a/includes/sdk/FreemiusWordPress.php
+++ b/includes/sdk/FreemiusWordPress.php
@@ -354,8 +354,11 @@
             $response = wp_remote_request( $pUrl, $pWPRemoteArgs );
 
             if (
-                empty( $response['headers'] ) ||
-                empty( $response['headers']['x-api-server'] )
+                is_array( $response ) &&
+                (
+                    empty( $response['headers'] ) ||
+                    empty( $response['headers']['x-api-server'] )
+                )
             ) {
                 // API is considered blocked if the response doesn't include the `x-api-server` header. When there's no error but this header doesn't exist, the response is usually not in the expected form (e.g., cannot be JSON-decoded).
                 $response = new WP_Error( 'api_blocked', htmlentities( $response['body'] ) );

--- a/includes/sdk/FreemiusWordPress.php
+++ b/includes/sdk/FreemiusWordPress.php
@@ -348,7 +348,7 @@
          * @param string $pUrl
          * @param array  $pWPRemoteArgs
          *
-         * @return mixed
+         * @return array|WP_Error The response array or a WP_Error on failure.
          */
         static function RemoteRequest( $pUrl, $pWPRemoteArgs ) {
             $response = wp_remote_request( $pUrl, $pWPRemoteArgs );

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.5.5';
+	$this_sdk_version = '2.5.5.1';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
…he response is an array as it can also be a WP_Error instance.