### PR TITLE
[license-activation] [links] Update Links in the Opt-In and License Activation UI

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -10298,7 +10298,20 @@
         function get_usage_tracking_terms_url() {
             return $this->apply_filters(
                 'usage_tracking_terms_url',
-                "https://freemius.com/wordpress/usage-tracking/{$this->_plugin->id}/{$this->_slug}/"
+                "https://freemius.com/product/opt-in/{$this->_plugin->id}/{$this->_slug}/"
+            );
+        }
+
+        /**
+         * @todo (For LiteSDK) We can refactor this and other related functions giving links to several landing pages on freemius.com to come from a separate class like `FS_Terms_Pages`. This would get a `FS_WP_Hook` (hypothetical) instance as a dependency and use it to hook into the `license_activation_terms_url` or related filters. The entry level instance from `ms_fs()` would hold a public read-only variable `my_fs()->terms_pages` which would be an instance of `FS_Terms_Pages` and would hold all the links to the terms pages.
+         * @since 2.5.8
+         *
+         * @return string
+         */
+        function get_license_activation_terms_url() {
+            return $this->apply_filters(
+                'license_activation_terms_url',
+                "https://freemius.com/product/license-activation/{$this->_plugin->id}/{$this->_slug}/"
             );
         }
 

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.5.7';
+	$this_sdk_version = '2.5.7.1';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/templates/connect.php
+++ b/templates/connect.php
@@ -47,23 +47,9 @@
 		$site_url = substr( $site_url, $protocol_pos + 3 );
 	}
 
-	$freemius_site_www = 'https://freemius.com';
-
 	$freemius_usage_tracking_url = $fs->get_usage_tracking_terms_url();
 	$freemius_plugin_terms_url   = $fs->get_eula_url();
-
-	$freemius_site_url = $fs->is_premium() ?
-		$freemius_site_www :
-		$freemius_usage_tracking_url;
-
-	if ( $fs->is_premium() ) {
-		$freemius_site_url .= '?' . http_build_query( array(
-				'id'   => $fs->get_id(),
-				'slug' => $slug,
-			) );
-	}
-
-	$freemius_link = '<a href="' . $freemius_site_url . '" target="_blank" rel="noopener" tabindex="1">freemius.com</a>';
+	$freemius_generic_terms_url  = 'https://freemius.com/terms/';
 
 	$error = fs_request_get( 'error' );
 
@@ -75,6 +61,12 @@
                                ( $is_premium_code || ! $has_release_on_freemius ) &&
                                fs_request_get_bool( 'require_license', ( $is_premium_code || $has_release_on_freemius ) )
                            );
+
+	$freemius_activation_terms_url = ($fs->is_premium() && $require_license_key) ?
+		$fs->get_license_activation_terms_url() :
+		$freemius_usage_tracking_url;
+
+	$freemius_activation_terms_html = '<a href="' . $freemius_activation_terms_url . '" target="_blank" rel="noopener" tabindex="1">freemius.com</a>';
 
 	if ( $is_pending_activation ) {
 		$require_license_key = false;
@@ -265,13 +257,13 @@
 								'<b>' . esc_html( $fs->get_plugin_name() ) . '</b>',
 								'<b>' . $current_user->user_login . '</b>',
 								'<a href="' . $site_url . '" target="_blank" rel="noopener noreferrer">' . $site_url . '</a>',
-                                $freemius_link
+                                $freemius_activation_terms_html
 							),
 							$first_name,
 							$fs->get_plugin_name(),
 							$current_user->user_login,
 							'<a href="' . $site_url . '" target="_blank" rel="noopener noreferrer">' . $site_url . '</a>',
-							$freemius_link,
+							$freemius_activation_terms_html,
 							true
 						);
 					}
@@ -451,12 +443,12 @@
 		<?php endif ?>
         </div>
 		<div class="fs-terms">
-            <a class="fs-tooltip-trigger<?php echo is_rtl() ? ' rtl' : '' ?>" href="<?php echo $freemius_site_url ?>" target="_blank" rel="noopener" tabindex="1">Powered by Freemius<?php if ( $require_license_key ) : ?> <span class="fs-tooltip" style="width: 170px"><?php echo $fs->get_text_inline( 'Freemius is our licensing and software updates engine', 'permissions-extensions_desc' ) ?></span><?php endif ?></a>
+            <a class="fs-tooltip-trigger<?php echo is_rtl() ? ' rtl' : '' ?>" href="<?php echo $freemius_activation_terms_url ?>" target="_blank" rel="noopener" tabindex="1">Powered by Freemius<?php if ( $require_license_key ) : ?> <span class="fs-tooltip" style="width: 170px"><?php echo $fs->get_text_inline( 'Freemius is our licensing and software updates engine', 'permissions-extensions_desc' ) ?></span><?php endif ?></a>
             &nbsp;&nbsp;-&nbsp;&nbsp;
 			<a href="https://freemius.com/privacy/" target="_blank" rel="noopener"
 			   tabindex="1"><?php fs_esc_html_echo_inline( 'Privacy Policy', 'privacy-policy', $slug ) ?></a>
 			&nbsp;&nbsp;-&nbsp;&nbsp;
-			<a href="<?php echo $require_license_key ? $freemius_plugin_terms_url : $freemius_usage_tracking_url ?>" target="_blank" rel="noopener" tabindex="1"><?php $require_license_key ? fs_echo_inline( 'License Agreement', 'license-agreement', $slug ) : fs_echo_inline( 'Terms of Service', 'tos', $slug ) ?></a>
+			<a href="<?php echo $require_license_key ? $freemius_plugin_terms_url : $freemius_generic_terms_url ?>" target="_blank" rel="noopener" tabindex="1"><?php $require_license_key ? fs_echo_inline( 'License Agreement', 'license-agreement', $slug ) : fs_echo_inline( 'Terms of Service', 'tos', $slug ) ?></a>
 		</div>
 	</div>
 	<?php

--- a/templates/connect.php
+++ b/templates/connect.php
@@ -49,7 +49,6 @@
 
 	$freemius_usage_tracking_url = $fs->get_usage_tracking_terms_url();
 	$freemius_plugin_terms_url   = $fs->get_eula_url();
-	$freemius_generic_terms_url  = 'https://freemius.com/terms/';
 
 	$error = fs_request_get( 'error' );
 
@@ -66,7 +65,7 @@
 		$fs->get_license_activation_terms_url() :
 		$freemius_usage_tracking_url;
 
-	$freemius_activation_terms_html = '<a href="' . $freemius_activation_terms_url . '" target="_blank" rel="noopener" tabindex="1">freemius.com</a>';
+	$freemius_activation_terms_html = '<a href="' . esc_attr( $freemius_activation_terms_url ) . '" target="_blank" rel="noopener" tabindex="1">freemius.com</a>';
 
 	if ( $is_pending_activation ) {
 		$require_license_key = false;
@@ -443,12 +442,16 @@
 		<?php endif ?>
         </div>
 		<div class="fs-terms">
-            <a class="fs-tooltip-trigger<?php echo is_rtl() ? ' rtl' : '' ?>" href="<?php echo $freemius_activation_terms_url ?>" target="_blank" rel="noopener" tabindex="1">Powered by Freemius<?php if ( $require_license_key ) : ?> <span class="fs-tooltip" style="width: 170px"><?php echo $fs->get_text_inline( 'Freemius is our licensing and software updates engine', 'permissions-extensions_desc' ) ?></span><?php endif ?></a>
+            <a class="fs-tooltip-trigger<?php echo is_rtl() ? ' rtl' : '' ?>" href="<?php echo esc_attr( $freemius_activation_terms_url ) ?>" target="_blank" rel="noopener" tabindex="1">Powered by Freemius<?php if ( $require_license_key ) : ?> <span class="fs-tooltip" style="width: 170px"><?php echo $fs->get_text_inline( 'Freemius is our licensing and software updates engine', 'permissions-extensions_desc' ) ?></span><?php endif ?></a>
             &nbsp;&nbsp;-&nbsp;&nbsp;
 			<a href="https://freemius.com/privacy/" target="_blank" rel="noopener"
 			   tabindex="1"><?php fs_esc_html_echo_inline( 'Privacy Policy', 'privacy-policy', $slug ) ?></a>
 			&nbsp;&nbsp;-&nbsp;&nbsp;
-			<a href="<?php echo $require_license_key ? $freemius_plugin_terms_url : $freemius_generic_terms_url ?>" target="_blank" rel="noopener" tabindex="1"><?php $require_license_key ? fs_echo_inline( 'License Agreement', 'license-agreement', $slug ) : fs_echo_inline( 'Terms of Service', 'tos', $slug ) ?></a>
+			<?php if ($require_license_key) : ?>
+				<a href="<?php echo esc_attr( $freemius_plugin_terms_url ) ?>" target="_blank" rel="noopener" tabindex="1"><?php fs_echo_inline( 'License Agreement', 'license-agreement', $slug ) ?></a>
+			<?php else : ?>
+				<a href="<?php echo esc_attr( $freemius_usage_tracking_url ) ?>" target="_blank" rel="noopener" tabindex="1"><?php fs_echo_inline( 'Terms of Service', 'tos', $slug ) ?></a>
+			<?php endif; ?>
 		</div>
 	</div>
 	<?php


### PR DESCRIPTION
- [x] Update the links for the "Powered by Fremius" anchor when activating the license.
- [x] Use the new `product/opt-in/` link for generating the usage-tracking terms URL.
- [x] Fix using the `/product/license-activation/` link only when the user is actually activating a license and not when trying to activate the free version.
