### PR TITLE
Fix warning when site has no `plan_id`

### DIFF
--- a/includes/entities/class-fs-site.php
+++ b/includes/entities/class-fs-site.php
@@ -119,7 +119,9 @@
             parent::__construct( $site );
 
             if ( is_object( $site ) ) {
-                $this->plan_id = $site->plan_id;
+                if ( ! empty( $site->plan_id ) ) {
+                    $this->plan_id = $site->plan_id;
+                }
             }
 
             if ( ! is_bool( $this->is_disconnected ) ) {


### PR DESCRIPTION
Fixes #638 