### PR TITLE
Fix of strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated

### DIFF
--- a/templates/account/partials/addon.php
+++ b/templates/account/partials/addon.php
@@ -240,19 +240,19 @@
                         true
                     );
 
-                    $human_readable_license_expiration = human_time_diff( time(), strtotime( $license->expiration ) );
-                    $downgrade_confirmation_message    = sprintf(
-                        $downgrade_x_confirm_text,
-                        ( $fs_addon->is_only_premium() ? $cancelling_subscription_text : $downgrading_plan_text ),
-                        $plan->title,
-                        $human_readable_license_expiration
-                    );
-
                     $after_downgrade_message = ! $license->is_block_features ?
                         sprintf( $after_downgrade_non_blocking_text, $plan->title, $fs_addon->get_module_label( true ) ) :
                         sprintf( $after_downgrade_blocking_text, $plan->title );
 
                     if ( ! $license->is_lifetime() && $is_active_subscription ) {
+                        $human_readable_license_expiration = human_time_diff( time(), strtotime( $license->expiration ) );
+                        $downgrade_confirmation_message    = sprintf(
+                            $downgrade_x_confirm_text,
+                            ( $fs_addon->is_only_premium() ? $cancelling_subscription_text : $downgrading_plan_text ),
+                            $plan->title,
+                            $human_readable_license_expiration
+                        );
+
                         $buttons[] = fs_ui_get_action_button(
                             $fs->get_id(),
                             'account',


### PR DESCRIPTION
[templates] [addon] [bug-fix] The `expiration` prop of a lifetime license is `null`, so `strtotime()` is throwing a PHP error for that case. Therefore, I moved the string generation logic into the `if` statement, ensuring the license is not lifetime and is associated with an active subscription.