### PR TITLE
Fix block theme preview issue on WP 6.3.2 and above

### DIFF
--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.6.0.1';
+	$this_sdk_version = '2.6.1';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.6.0';
+	$this_sdk_version = '2.6.0.1';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 
@@ -47,15 +47,20 @@
 	$file_path    = fs_normalize_path( __FILE__ );
 	$fs_root_path = dirname( $file_path );
 
+    // @todo: Remove this code after a few months when WP 6.3 usage is low enough.
+    global $wp_version;
+
     if (
         ! function_exists( 'wp_get_current_user' ) &&
         /**
          * `get_stylesheet()` will rely on `wp_get_current_user()` when it is being filtered by `theme-previews.php`. That happens only when the site editor is loaded or when the site editor is sending REST requests.
          * @see theme-previews.php:wp_get_theme_preview_path()
          *
-         * @todo If this behavior is fixed in the core, we will remove this workaround.
+         * @todo This behavior is already fixed in the core (WP 6.3.2+), and this code can be removed after a few months when WP 6.3 usage is low enough.
          * @since WP 6.3.0
          */
+        version_compare( $wp_version, '6.3', '>=' ) &&
+        version_compare( $wp_version, '6.3.1', '<=' ) &&
         (
             'site-editor.php' === basename( $_SERVER['SCRIPT_FILENAME'] ) ||
             (


### PR DESCRIPTION
We identified (thanks to the community) that our temporary patch to fix the block theme preview issue for WP versions 6.3 and 6.3.1 had regressions for WP version 6.3.2 and above.

Since the original issue itself was a bug from the WordPress core that has now been fixed, we have scoped our fix for the specific WP 6.3 and 6.3.1 versions. We plan to remove the patch altogether after a few months when the usage is low enough. This ensures we continue supporting WP 6.3, 6.3.1, and 6.3.2+ versions.