### PR TITLE
Fix: PHP error for missing title and language keys

### DIFF
--- a/templates/partials/network-activation.php
+++ b/templates/partials/network-activation.php
@@ -58,7 +58,7 @@
     <div class="fs-sites-list-container">
         <table cellspacing="0">
             <tbody>
-            <?php $site_props = array('uid', 'url', 'title', 'language') ?>
+            <?php $site_props = array('uid', 'url') ?>
             <?php foreach ( $sites as $site ) : ?>
                 <tr<?php if ( ! empty( $site['license_id'] ) ) {
                     echo ' data-license-id="' . esc_attr( $site['license_id'] ) . '"';


### PR DESCRIPTION
The PHP error appears when changing or activating a license using the beta multisite feature