### PR TITLE
Version 2.6.2

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -1357,8 +1357,7 @@
         }
 
         function _run_garbage_collector() {
-            // @todo - Remove this check once the garbage collector is ready to be out of beta.
-            if ( true !== fs_get_optional_constant( 'WP_FS__ENABLE_GARBAGE_COLLECTOR', false ) ) {
+            if ( true !== fs_get_optional_constant( 'WP_FS__ENABLE_GARBAGE_COLLECTOR', true ) ) {
                 return;
             }
 

--- a/includes/class-fs-garbage-collector.php
+++ b/includes/class-fs-garbage-collector.php
@@ -281,7 +281,7 @@
             $has_updated_option = false;
 
             foreach ( $users as $user_id => $user ) {
-                if ( ! isset( $user_has_install[ $user_id ] ) ) {
+                if ( ! isset( $user_has_install_map[ $user_id ] ) ) {
                     unset( $users[ $user_id ] );
 
                     foreach( $products_user_id_license_ids_map as $product_id => $user_id_license_ids_map ) {

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.6.1.1';
+	$this_sdk_version = '2.6.2';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.6.1';
+	$this_sdk_version = '2.6.1.1';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
## Enable garbage collector by default

Starting v2.6.2 we have enabled the garbage collector system by default. More information about it can be found [here](https://github.com/Freemius/wordpress-sdk/releases/tag/2.6.0).

If for some reason you want to explicitly disable it (for example, while you are developing something locally), you can do so by defining this constant in your `wp-config.php` file.

```php
// Disable Freemius WP-SDK Garbage Collector
if ( ! defined( 'WP_FS__ENABLE_GARBAGE_COLLECTOR' ) ) {
    define( 'WP_FS__ENABLE_GARBAGE_COLLECTOR', false );
}
```

The Garbage Collector will run once every day and will clear data of any plugins/themes that have not been active for more than 1 week.

You can configure the expiration time with another constant:

```php
// Set expiration time to 30 days
if ( ! defined( 'WP_FS__GARBAGE_COLLECTOR_EXPIRATION_TIME_SECS' ) ) {
    define( 'WP_FS__GARBAGE_COLLECTOR_EXPIRATION_TIME_SECS', ( 30 * 24 * 60 * 60 ) );	
}
```