### PR TITLE
[wordpress-compliance] Fix the loading/enqueueing of JS scripts in WP.

### DIFF
--- a/includes/fs-core-functions.php
+++ b/includes/fs-core-functions.php
@@ -118,7 +118,7 @@
     }
 
     if ( ! function_exists( 'fs_enqueue_local_script' ) ) {
-        function fs_enqueue_local_script( $handle, $path, $deps = array(), $ver = false, $in_footer = false ) {
+        function fs_enqueue_local_script( $handle, $path, $deps = array(), $ver = false, $in_footer = true ) {
             wp_enqueue_script( $handle, fs_asset_url( WP_FS__DIR_JS . '/' . trim( $path, '/' ) ), $deps, $ver, $in_footer );
         }
     }

--- a/includes/fs-core-functions.php
+++ b/includes/fs-core-functions.php
@@ -118,7 +118,7 @@
     }
 
     if ( ! function_exists( 'fs_enqueue_local_script' ) ) {
-        function fs_enqueue_local_script( $handle, $path, $deps = array(), $ver = false, $in_footer = 'all' ) {
+        function fs_enqueue_local_script( $handle, $path, $deps = array(), $ver = false, $in_footer = false ) {
             wp_enqueue_script( $handle, fs_asset_url( WP_FS__DIR_JS . '/' . trim( $path, '/' ) ), $deps, $ver, $in_footer );
         }
     }


### PR DESCRIPTION
- [x] Fix the loading/enqueueing of JS scripts in WP.. The default is false to load in the head. Ref: https://developer.wordpress.org/reference/functions/wp_enqueue_script/#parameters