### PR TITLE
[php82] Suppress PHP 8.2+ warnings for dynamic properties.

### DIFF
--- a/includes/entities/class-fs-site.php
+++ b/includes/entities/class-fs-site.php
@@ -13,6 +13,7 @@
     /**
      * @property int $blog_id
      */
+    #[AllowDynamicProperties]
     class FS_Site extends FS_Scope_Entity {
         /**
          * @var number


### PR DESCRIPTION
- [x] Add #[AllowDynamicProperties] comment to suppress PHP 8.2+ warnings. The attribute will automatically be inherited by child classes. Fixes https://github.com/Freemius/wordpress-sdk/issues/623

Reference: [https://wiki.php.net/rfc/deprecate_dynamic_properties PHP RFC: Deprecate dynamic properties].

**How to Test.**
1. Ensure your WP instance is running on PHP 8.2+
2. Install Query Monitor with the latest SDK `develop` or `master` branch in use with any plugin. 
![CleanShot 2024-02-11 at 18 07 00](https://github.com/Freemius/wordpress-sdk/assets/7713923/64ee2203-d264-4ee8-9d49-4fa85efdcc77)
3. Change to the `feature/suppress-missing-dynamic-properties` branch 
![CleanShot 2024-02-11 at 17 51 06](https://github.com/Freemius/wordpress-sdk/assets/7713923/2c361532-eeb6-4a51-81a0-dcc28ebedf5b)
