### PR TITLE
[debug] [logging] Automatically turn off `fs_debug_mode`after 24 hours

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -1257,7 +1257,7 @@
          *
          * @return bool
          */
-        private static function set_network_upgrade_mode( FS_Storage $storage ) {
+        public static function set_network_upgrade_mode( FS_Storage $storage ) {
             return $storage->is_network_activation = true;
         }
 
@@ -1583,6 +1583,8 @@
             ) {
                 add_action( 'admin_init', array( &$this, 'connect_again' ) );
             }
+
+            FS_DebugManager::register_hooks();
         }
 
         /**
@@ -2701,7 +2703,7 @@
          * @author Vova Feldman (@svovaf)
          * @since  2.4.3
          */
-        private static function reset_deactivation_snoozing( $period = 0 ) {
+        public static function reset_deactivation_snoozing( $period = 0 ) {
             $value = ( 0 === $period ) ? null : 'true';
 
             if ( ! is_multisite() || fs_is_network_admin() ) {
@@ -3418,20 +3420,7 @@
 
             self::$_global_admin_notices = FS_Admin_Notices::instance( 'global' );
 
-            if ( ! WP_FS__DEMO_MODE ) {
-                add_action( ( fs_is_network_admin() ? 'network_' : '' ) . 'admin_menu', array(
-                    'Freemius',
-                    '_add_debug_section'
-                ) );
-            }
-
-            add_action( "wp_ajax_fs_toggle_debug_mode", array( 'Freemius', '_toggle_debug_mode' ) );
-
-            self::add_ajax_action_static( 'get_debug_log', array( 'Freemius', '_get_debug_log' ) );
-
-            self::add_ajax_action_static( 'get_db_option', array( 'Freemius', '_get_db_option' ) );
-
-            self::add_ajax_action_static( 'set_db_option', array( 'Freemius', '_set_db_option' ) );
+            FS_DebugManager::load_required_static();
 
             if ( 0 == did_action( 'plugins_loaded' ) ) {
                 add_action( 'plugins_loaded', array( 'Freemius', '_load_textdomain' ), 1 );
@@ -3456,6 +3445,14 @@
             }
 
             self::$_statics_loaded = true;
+        }
+
+        public static function get_static_logger() {
+            return self::$_static_logger;
+        }
+
+        public static function get_accounts() {
+            return self::$_accounts;
         }
 
         #--------------------------------------------------------------------------------
@@ -3626,7 +3623,7 @@
          *
          * @since 2.1.3
          */
-        private static function migrate_options_to_network() {
+        public static function migrate_options_to_network() {
             self::migrate_accounts_to_network();
 
             // Migrate API options from site level to network level.
@@ -3662,325 +3659,6 @@
                 false,
                 $fs_active_plugins->newest->sdk_path . '/languages/'
             );
-        }
-
-        #endregion
-
-        #----------------------------------------------------------------------------------
-        #region Debugging
-        #----------------------------------------------------------------------------------
-
-        /**
-         * @author Vova Feldman (@svovaf)
-         * @since  1.0.8
-         */
-        static function _add_debug_section() {
-            if ( ! is_super_admin() ) {
-                // Add debug page only for super-admins.
-                return;
-            }
-
-            self::$_static_logger->entrance();
-
-            $title = sprintf( '%s [v.%s]', fs_text_inline( 'Freemius Debug' ), WP_FS__SDK_VERSION );
-
-            if ( WP_FS__DEV_MODE ) {
-                // Add top-level debug menu item.
-                $hook = FS_Admin_Menu_Manager::add_page(
-                    $title,
-                    $title,
-                    'manage_options',
-                    'freemius',
-                    array( 'Freemius', '_debug_page_render' )
-                );
-            } else {
-                // Add hidden debug page.
-                $hook = FS_Admin_Menu_Manager::add_subpage(
-                    '',
-                    $title,
-                    $title,
-                    'manage_options',
-                    'freemius',
-                    array( 'Freemius', '_debug_page_render' )
-                );
-            }
-
-            if ( ! empty( $hook ) ) {
-                add_action( "load-$hook", array( 'Freemius', '_debug_page_actions' ) );
-            }
-        }
-
-        /**
-         * @author Vova Feldman (@svovaf)
-         * @since  1.1.7.3
-         */
-        static function _toggle_debug_mode() {
-            check_admin_referer( 'fs_toggle_debug_mode' );
-
-            if ( ! is_super_admin() ) {
-                return;
-            }
-
-            $is_on = fs_request_get( 'is_on', false, 'post' );
-
-            if ( fs_request_is_post() && in_array( $is_on, array( 0, 1 ) ) ) {
-                update_option( 'fs_debug_mode', $is_on );
-
-                // Turn on/off storage logging.
-                FS_Logger::_set_storage_logging( ( 1 == $is_on ) );
-            }
-
-            exit;
-        }
-
-        /**
-         * @author Vova Feldman (@svovaf)
-         * @since  1.2.1.6
-         */
-        static function _get_debug_log() {
-            check_admin_referer( 'fs_get_debug_log' );
-
-            if ( ! is_super_admin() ) {
-                return;
-            }
-
-            $limit  = min( ! empty( $_POST['limit'] ) ? absint( $_POST['limit'] ) : 200, 200 );
-            $offset = min( ! empty( $_POST['offset'] ) ? absint( $_POST['offset'] ) : 200, 200 );
-
-            $logs = FS_Logger::load_db_logs(
-                fs_request_get( 'filters', false, 'post' ),
-                $limit,
-                $offset
-            );
-
-            self::shoot_ajax_success( $logs );
-        }
-
-        /**
-         * @author Vova Feldman (@svovaf)
-         * @since  1.2.1.7
-         */
-        static function _get_db_option() {
-            check_admin_referer( 'fs_get_db_option' );
-
-            $option_name = fs_request_get( 'option_name' );
-
-            if ( ! is_super_admin() ||
-                 ! fs_starts_with( $option_name, 'fs_' )
-            ) {
-                self::shoot_ajax_failure();
-            }
-
-            $value = get_option( $option_name );
-
-            $result = array(
-                'name' => $option_name,
-            );
-
-            if ( false !== $value ) {
-                if ( ! is_string( $value ) ) {
-                    $value = json_encode( $value );
-                }
-
-                $result['value'] = $value;
-            }
-
-            self::shoot_ajax_success( $result );
-        }
-
-        /**
-         * @author Vova Feldman (@svovaf)
-         * @since  1.2.1.7
-         */
-        static function _set_db_option() {
-            check_admin_referer( 'fs_set_db_option' );
-
-            $option_name = fs_request_get( 'option_name' );
-
-            if ( ! is_super_admin() ||
-                 ! fs_starts_with( $option_name, 'fs_' )
-            ) {
-                self::shoot_ajax_failure();
-            }
-
-            $option_value = fs_request_get_raw( 'option_value' );
-
-            if ( ! empty( $option_value ) ) {
-                update_option( $option_name, $option_value );
-            }
-
-            self::shoot_ajax_success();
-        }
-
-        /**
-         * @author Vova Feldman (@svovaf)
-         * @since  1.0.8
-         */
-        static function _debug_page_actions() {
-            self::_clean_admin_content_section();
-
-            if ( fs_request_is_action( 'restart_freemius' ) ) {
-                check_admin_referer( 'restart_freemius' );
-
-                if ( ! is_multisite() ) {
-                    // Clear accounts data.
-                    self::$_accounts->clear( null, true );
-                } else {
-                    $sites = self::get_sites();
-                    foreach ( $sites as $site ) {
-                        $blog_id = self::get_site_blog_id( $site );
-                        self::$_accounts->clear( $blog_id, true );
-                    }
-
-                    // Clear network level storage.
-                    self::$_accounts->clear( true, true );
-                }
-
-                // Clear SDK reference cache.
-                delete_option( 'fs_active_plugins' );
-            } else if ( fs_request_is_action( 'clear_updates_data' ) ) {
-                check_admin_referer( 'clear_updates_data' );
-
-                if ( ! is_multisite() ) {
-                    set_site_transient( 'update_plugins', null );
-                    set_site_transient( 'update_themes', null );
-                } else {
-                    $current_blog_id = get_current_blog_id();
-
-                    $sites = self::get_sites();
-                    foreach ( $sites as $site ) {
-                        switch_to_blog( self::get_site_blog_id( $site ) );
-
-                        set_site_transient( 'update_plugins', null );
-                        set_site_transient( 'update_themes', null );
-                    }
-
-                    switch_to_blog( $current_blog_id );
-                }
-            } else if ( fs_request_is_action( 'reset_deactivation_snoozing' ) ) {
-                check_admin_referer( 'reset_deactivation_snoozing' );
-
-                self::reset_deactivation_snoozing();
-            } else if ( fs_request_is_action( 'simulate_trial' ) ) {
-                check_admin_referer( 'simulate_trial' );
-
-                $fs = freemius( fs_request_get( 'module_id' ) );
-
-                // Update SDK install to at least 24 hours before.
-                $fs->_storage->install_timestamp = ( time() - WP_FS__TIME_24_HOURS_IN_SEC );
-                // Unset the trial shown timestamp.
-                unset( $fs->_storage->trial_promotion_shown );
-            } else if ( fs_request_is_action( 'simulate_network_upgrade' ) ) {
-                check_admin_referer( 'simulate_network_upgrade' );
-
-                $fs = freemius( fs_request_get( 'module_id' ) );
-
-                self::set_network_upgrade_mode( $fs->_storage );
-            } else if ( fs_request_is_action( 'delete_install' ) ) {
-                check_admin_referer( 'delete_install' );
-
-                self::_delete_site_by_slug(
-                    fs_request_get( 'slug' ),
-                    fs_request_get( 'module_type' ),
-                    true,
-                    fs_request_get( 'blog_id', null )
-                );
-            } else if ( fs_request_is_action( 'delete_user' ) ) {
-                check_admin_referer( 'delete_user' );
-
-                self::delete_user( fs_request_get( 'user_id' ) );
-            } else if ( fs_request_is_action( 'download_logs' ) ) {
-                check_admin_referer( 'download_logs' );
-
-                $download_url = FS_Logger::download_db_logs(
-                    fs_request_get( 'filters', false, 'post' )
-                );
-
-                if ( false === $download_url ) {
-                    wp_die( 'Oops... there was an error while generating the logs download file. Please try again and if it doesn\'t work contact support@freemius.com.' );
-                }
-
-                fs_redirect( $download_url );
-            } else if ( fs_request_is_action( 'migrate_options_to_network' ) ) {
-                check_admin_referer( 'migrate_options_to_network' );
-
-                self::migrate_options_to_network();
-            }
-        }
-
-        /**
-         * @author Leo Fajardo (@leorw)
-         * @since  2.5.0
-         * 
-         * @return array
-         */
-        static function get_all_modules_sites() {
-            self::$_static_logger->entrance();
-
-            $sites_by_type = array(
-                WP_FS__MODULE_TYPE_PLUGIN => array(),
-                WP_FS__MODULE_TYPE_THEME  => array(),
-            );
-
-            $module_types = array_keys( $sites_by_type );
-
-            if ( ! is_multisite() ) {
-                foreach ( $module_types as $type ) {
-                    $sites_by_type[ $type ] = self::get_all_sites( $type );
-
-                    foreach ( $sites_by_type[ $type ] as $slug => $install ) {
-                        $sites_by_type[ $type ][ $slug ] = array( $install );
-                    }
-                }
-            } else {
-                $sites = self::get_sites();
-
-                foreach ( $sites as $site ) {
-                    $blog_id = self::get_site_blog_id( $site );
-
-                    foreach ( $module_types as $type ) {
-                        $installs = self::get_all_sites( $type, $blog_id );
-
-                        foreach ( $installs as $slug => $install ) {
-                            if ( ! isset( $sites_by_type[ $type ][ $slug ] ) ) {
-                                $sites_by_type[ $type ][ $slug ] = array();
-                            }
-
-                            $install->blog_id = $blog_id;
-
-                            $sites_by_type[ $type ][ $slug ][] = $install;
-                        }
-
-                    }
-                }
-            }
-
-            return $sites_by_type;
-        }
-
-        /**
-         * @author Vova Feldman (@svovaf)
-         * @since  1.0.8
-         */
-        static function _debug_page_render() {
-            self::$_static_logger->entrance();
-
-            $all_modules_sites = self::get_all_modules_sites();
-
-            $licenses_by_module_type = self::get_all_licenses_by_module_type();
-
-            $vars = array(
-                'plugin_sites'    => $all_modules_sites[ WP_FS__MODULE_TYPE_PLUGIN ],
-                'theme_sites'     => $all_modules_sites[ WP_FS__MODULE_TYPE_THEME ],
-                'users'           => self::get_all_users(),
-                'addons'          => self::get_all_addons(),
-                'account_addons'  => self::get_all_account_addons(),
-                'plugin_licenses' => $licenses_by_module_type[ WP_FS__MODULE_TYPE_PLUGIN ],
-                'theme_licenses'  => $licenses_by_module_type[ WP_FS__MODULE_TYPE_THEME ]
-            );
-
-            fs_enqueue_local_style( 'fs_debug', '/admin/debug.css' );
-            fs_require_once_template( 'debug.php', $vars );
         }
 
         #endregion
@@ -7483,31 +7161,6 @@
         }
 
         /**
-         * Delete user.
-         *
-         * @author Vova Feldman (@svovaf)
-         * @since  2.0.0
-         *
-         * @param number $user_id
-         * @param bool   $store
-         *
-         * @return false|int The user ID if deleted. Otherwise, FALSE (when install not exist).
-         */
-        private static function delete_user( $user_id, $store = true ) {
-            $users = self::get_all_users();
-
-            if ( ! is_array( $users ) || ! isset( $users[ $user_id ] ) ) {
-                return false;
-            }
-
-            unset( $users[ $user_id ] );
-
-            self::$_accounts->set_option( 'users', $users, $store );
-
-            return $user_id;
-        }
-
-        /**
          * Delete plugin's plans information.
          *
          * @param bool $store                 Flush to Database if true.
@@ -10642,7 +10295,7 @@
          *
          * @return array[string]FS_Site
          */
-        private static function get_all_sites(
+        public static function get_all_sites(
             $module_type = WP_FS__MODULE_TYPE_PLUGIN,
             $blog_id = null,
             $is_backup = false
@@ -10671,7 +10324,7 @@
          *
          * @return mixed
          */
-        private static function get_account_option( $option_name, $module_type = null, $network_level_or_blog_id = null ) {
+        public static function get_account_option( $option_name, $module_type = null, $network_level_or_blog_id = null ) {
             if ( ! is_null( $module_type ) && WP_FS__MODULE_TYPE_PLUGIN !== $module_type ) {
                 $option_name = $module_type . '_' . $option_name;
             }
@@ -10800,36 +10453,6 @@
                 array();
 
             return $licenses;
-        }
-
-        /**
-         * @author Leo Fajardo (@leorw)
-         * @since  2.0.0
-         *
-         * @return array
-         */
-        private static function get_all_licenses_by_module_type() {
-            $licenses = self::get_account_option( 'all_licenses' );
-
-            $licenses_by_module_type = array(
-                WP_FS__MODULE_TYPE_PLUGIN => array(),
-                WP_FS__MODULE_TYPE_THEME  => array()
-            );
-
-            if ( ! is_array( $licenses ) ) {
-                return $licenses_by_module_type;
-            }
-
-            foreach ( $licenses as $module_id => $module_licenses ) {
-                $fs = self::get_instance_by_id( $module_id );
-                if ( false === $fs ) {
-                    continue;
-                }
-
-                $licenses_by_module_type[ $fs->_module_type ] = array_merge( $licenses_by_module_type[ $fs->_module_type ], $module_licenses );
-            }
-
-            return $licenses_by_module_type;
         }
 
         /**
@@ -10974,7 +10597,7 @@
          *
          * @return array<number,FS_Plugin[]>|false
          */
-        private static function get_all_addons() {
+        public static function get_all_addons() {
             $addons = self::maybe_get_entities_account_option( 'addons', array() );
 
             if ( ! is_array( $addons ) ) {
@@ -10990,7 +10613,7 @@
          *
          * @return number[]|false
          */
-        private static function get_all_account_addons() {
+        public static function get_all_account_addons() {
             $addons = self::$_accounts->get_option( 'account_addons', array() );
 
             if ( ! is_array( $addons ) ) {
@@ -11105,6 +10728,16 @@
          */
         function get_site() {
             return $this->_site;
+        }
+
+        /**
+         * @author Daniele Alessandra (@danielealessandra)
+         * @return FS_Storage
+         * @since  2.6.2
+         *
+         */
+        public function get_storage() {
+            return $this->_storage;
         }
 
         /**
@@ -24888,27 +24521,6 @@
          * @author Leo Fajardo (@leorw)
          * @since 2.1.0
          *
-         * @param string $url
-         * @param array  $request
-         */
-        private static function enrich_request_for_debug( &$url, &$request ) {
-            if ( WP_FS__DEBUG_SDK || isset( $_COOKIE['XDEBUG_SESSION'] ) ) {
-                $url = add_query_arg( 'XDEBUG_SESSION_START', rand( 0, 9999999 ), $url );
-                $url = add_query_arg( 'XDEBUG_SESSION', 'PHPSTORM', $url );
-
-                $request['cookies'] = array(
-                    new WP_Http_Cookie( array(
-                        'name'  => 'XDEBUG_SESSION',
-                        'value' => 'PHPSTORM',
-                    ) )
-                );
-            }
-        }
-
-        /**
-         * @author Leo Fajardo (@leorw)
-         * @since 2.1.0
-         *
          * @param string      $url
          * @param array       $request
          * @param int         $success_cache_expiration
@@ -24934,7 +24546,7 @@
 
             if ( false === $response ) {
                 if ( $maybe_enrich_request_for_debug ) {
-                    self::enrich_request_for_debug( $url, $request );
+                    FS_DebugManager::enrich_request_for_debug( $url, $request );
                 }
 
                 if ( ! isset( $request['method'] ) ) {

--- a/includes/class-fs-logger.php
+++ b/includes/class-fs-logger.php
@@ -119,7 +119,7 @@
 		}
 
 		function is_on() {
-			return $this->_on && self::$ON;
+			return $this->_on;
 		}
 
 		function on() {
@@ -338,6 +338,11 @@
 
 			$table = "{$wpdb->prefix}fs_logger";
 
+            /**
+             * Drop logging table in any case.
+             */
+            $result = $wpdb->query( "DROP TABLE IF EXISTS $table;" );
+
 			if ( $is_on ) {
 				/**
 				 * Create logging table.
@@ -367,10 +372,6 @@ KEY `process_logger` (`process_id` ASC, `logger` ASC),
 KEY `function` (`function` ASC),
 KEY `type` (`type` ASC))" );
 			} else {
-				/**
-				 * Drop logging table.
-				 */
-				$result = $wpdb->query( "DROP TABLE IF EXISTS $table;" );
                 /**
                  * Since logging table does not exist anymore, we need to turn off all instances
                  */
@@ -381,12 +382,11 @@ KEY `type` (`type` ASC))" );
                  * Also, we delete all references and turn off global logging
                  */
                 self::$LOGGERS = [];
-                self::$ON = false;
 			}
 
 			if ( false !== $result ) {
-                self::$ON = (bool) $is_on;
 				update_option( 'fs_storage_logger', ( $is_on ? 1 : 0 ) );
+                self::$_isStorageLoggingOn = $is_on;
 			}
 
 			return ( false !== $result );

--- a/includes/class-fs-logger.php
+++ b/includes/class-fs-logger.php
@@ -32,9 +32,9 @@
 		 */
 		private static $_abspathLength;
 
-        /**
-         * @var FS_Logger[] $LOGGERS
-         */
+		/**
+		 * @var FS_Logger[] $LOGGERS
+		 */
 		private static $LOGGERS = array();
 		private static $LOG = array();
 		private static $CNT = 0;
@@ -127,15 +127,6 @@
 
 			self::hook_footer();
 		}
-
-        /**
-         * Turn off instance
-         *
-         * @return void
-         */
-        public function off() {
-            $this->_on = false;
-        }
 		function echo_on() {
 			$this->on();
 
@@ -251,9 +242,6 @@
 		}
 
 		function entrance( $message = '', $wrapper = false ) {
-            if ( ! $this->is_on() ) {
-                return;
-            }
 			$msg = 'Entrance' . ( empty( $message ) ? '' : ' > ' ) . $message;
 
 			$this->_log( $msg, 'log', $wrapper );
@@ -334,10 +322,10 @@
 
 			$table = "{$wpdb->prefix}fs_logger";
 
-            /**
-             * Drop logging table in any case.
-             */
-            $result = $wpdb->query( "DROP TABLE IF EXISTS $table;" );
+			/**
+			 * Drop logging table in any case.
+			 */
+			$result = $wpdb->query( "DROP TABLE IF EXISTS $table;" );
 
 			if ( $is_on ) {
 				/**
@@ -367,22 +355,11 @@ KEY `process_id` (`process_id` ASC),
 KEY `process_logger` (`process_id` ASC, `logger` ASC),
 KEY `function` (`function` ASC),
 KEY `type` (`type` ASC))" );
-			} else {
-                /**
-                 * Since logging table does not exist anymore, we need to turn off all instances
-                 */
-                foreach ( self::$LOGGERS as $logger ) {
-                    $logger->off();
-                }
-                /**
-                 * Also, we delete all references and turn off global logging
-                 */
-                self::$LOGGERS = [];
 			}
 
 			if ( false !== $result ) {
 				update_option( 'fs_storage_logger', ( $is_on ? 1 : 0 ) );
-                self::$_isStorageLoggingOn = $is_on;
+				self::$_isStorageLoggingOn = $is_on;
 			}
 
 			return ( false !== $result );

--- a/includes/class-fs-logger.php
+++ b/includes/class-fs-logger.php
@@ -11,10 +11,6 @@
 	}
 
 	class FS_Logger {
-        /**
-         * @var bool
-         */
-        public static  $ON          = false;
 		private $_id;
 		private $_on = false;
 		private $_echo = false;

--- a/includes/class-fs-storage.php
+++ b/includes/class-fs-storage.php
@@ -20,6 +20,7 @@
      * @property bool|null   $is_extensions_tracking_allowed
      * @property bool|null   $is_diagnostic_tracking_allowed
      * @property object      $sync_cron
+     * @property bool|int    $install_timestamp
      */
     class FS_Storage {
         /**

--- a/includes/managers/class-fs-debug-manager.php
+++ b/includes/managers/class-fs-debug-manager.php
@@ -1,0 +1,511 @@
+<?php
+    /**
+     * @author    Daniele Alessandra (@danielealessandra)
+     * @copyright Copyright (c) 2024, Freemius, Inc.
+     * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU General Public License Version 3
+     * @package   Freemius
+     * @since     2.6.2
+     */
+
+    class FS_DebugManager {
+
+        /**
+         * @author Vova Feldman (@svovaf)
+         *  Moved from Freemius
+         *
+         * @since  1.0.8
+         */
+        static function _add_debug_section() {
+            if ( ! is_super_admin() ) {
+                // Add debug page only for super-admins.
+                return;
+            }
+
+            Freemius::get_static_logger()->entrance();
+
+            $title = sprintf( '%s [v.%s]', fs_text_inline( 'Freemius Debug' ), WP_FS__SDK_VERSION );
+
+            if ( WP_FS__DEV_MODE ) {
+                // Add top-level debug menu item.
+                $hook = FS_Admin_Menu_Manager::add_page(
+                    $title,
+                    $title,
+                    'manage_options',
+                    'freemius',
+                    array( self::class, '_debug_page_render' )
+                );
+            } else {
+                // Add hidden debug page.
+                $hook = FS_Admin_Menu_Manager::add_subpage(
+                    '',
+                    $title,
+                    $title,
+                    'manage_options',
+                    'freemius',
+                    array( self::class, '_debug_page_render' )
+                );
+            }
+
+            if ( ! empty( $hook ) ) {
+                add_action( "load-$hook", array( self::class, '_debug_page_actions' ) );
+            }
+        }
+
+        /**
+         * @author Vova Feldman (@svovaf)
+         *  Moved from Freemius
+         *
+         * @since  1.0.8
+         */
+        static function _debug_page_actions() {
+            Freemius::_clean_admin_content_section();
+
+            if ( fs_request_is_action( 'restart_freemius' ) ) {
+                check_admin_referer( 'restart_freemius' );
+
+                if ( ! is_multisite() ) {
+                    // Clear accounts data.
+                    Freemius::get_accounts()->clear( null, true );
+                } else {
+                    $sites = Freemius::get_sites();
+                    foreach ( $sites as $site ) {
+                        $blog_id = Freemius::get_site_blog_id( $site );
+                        Freemius::get_accounts()->clear( $blog_id, true );
+                    }
+
+                    // Clear network level storage.
+                    Freemius::get_accounts()->clear( true, true );
+                }
+
+                // Clear SDK reference cache.
+                delete_option( 'fs_active_plugins' );
+            } else if ( fs_request_is_action( 'clear_updates_data' ) ) {
+                check_admin_referer( 'clear_updates_data' );
+
+                if ( ! is_multisite() ) {
+                    set_site_transient( 'update_plugins', null );
+                    set_site_transient( 'update_themes', null );
+                } else {
+                    $current_blog_id = get_current_blog_id();
+
+                    $sites = Freemius::get_sites();
+                    foreach ( $sites as $site ) {
+                        switch_to_blog( Freemius::get_site_blog_id( $site ) );
+
+                        set_site_transient( 'update_plugins', null );
+                        set_site_transient( 'update_themes', null );
+                    }
+
+                    switch_to_blog( $current_blog_id );
+                }
+            } else if ( fs_request_is_action( 'reset_deactivation_snoozing' ) ) {
+                check_admin_referer( 'reset_deactivation_snoozing' );
+
+                Freemius::reset_deactivation_snoozing();
+            } else if ( fs_request_is_action( 'simulate_trial' ) ) {
+                check_admin_referer( 'simulate_trial' );
+
+                $fs = freemius( fs_request_get( 'module_id' ) );
+
+                // Update SDK install to at least 24 hours before.
+                $fs->get_storage()->install_timestamp = ( time() - WP_FS__TIME_24_HOURS_IN_SEC );
+                // Unset the trial shown timestamp.
+                unset( $fs->get_storage()->trial_promotion_shown );
+            } else if ( fs_request_is_action( 'simulate_network_upgrade' ) ) {
+                check_admin_referer( 'simulate_network_upgrade' );
+
+                $fs = freemius( fs_request_get( 'module_id' ) );
+
+                Freemius::set_network_upgrade_mode( $fs->get_storage() );
+            } else if ( fs_request_is_action( 'delete_install' ) ) {
+                check_admin_referer( 'delete_install' );
+
+                Freemius::_delete_site_by_slug(
+                    fs_request_get( 'slug' ),
+                    fs_request_get( 'module_type' ),
+                    true,
+                    fs_request_get( 'blog_id', null )
+                );
+            } else if ( fs_request_is_action( 'delete_user' ) ) {
+                check_admin_referer( 'delete_user' );
+
+                self::delete_user( fs_request_get( 'user_id' ) );
+            } else if ( fs_request_is_action( 'download_logs' ) ) {
+                check_admin_referer( 'download_logs' );
+
+                $download_url = FS_Logger::download_db_logs(
+                    fs_request_get( 'filters', false, 'post' )
+                );
+
+                if ( false === $download_url ) {
+                    wp_die( 'Oops... there was an error while generating the logs download file. Please try again and if it doesn\'t work contact support@freemius.com.' );
+                }
+
+                fs_redirect( $download_url );
+            } else if ( fs_request_is_action( 'migrate_options_to_network' ) ) {
+                check_admin_referer( 'migrate_options_to_network' );
+
+                Freemius::migrate_options_to_network();
+            }
+        }
+
+        /**
+         * @author Vova Feldman (@svovaf)
+         *  Moved from Freemius
+         *
+         * @since  1.0.8
+         */
+        static function _debug_page_render() {
+            Freemius::get_static_logger()->entrance();
+
+            $all_modules_sites = self::get_all_modules_sites();
+
+            $licenses_by_module_type = self::get_all_licenses_by_module_type();
+
+            $vars = array(
+                'plugin_sites'    => $all_modules_sites[ WP_FS__MODULE_TYPE_PLUGIN ],
+                'theme_sites'     => $all_modules_sites[ WP_FS__MODULE_TYPE_THEME ],
+                'users'           => Freemius::get_all_users(),
+                'addons'          => Freemius::get_all_addons(),
+                'account_addons'  => Freemius::get_all_account_addons(),
+                'plugin_licenses' => $licenses_by_module_type[ WP_FS__MODULE_TYPE_PLUGIN ],
+                'theme_licenses'  => $licenses_by_module_type[ WP_FS__MODULE_TYPE_THEME ],
+            );
+
+            fs_enqueue_local_style( 'fs_debug', '/admin/debug.css' );
+            fs_require_once_template( 'debug.php', $vars );
+        }
+
+        /**
+         * @author Vova Feldman (@svovaf)
+         *  Moved from Freemius
+         *
+         * @since  1.2.1.6
+         */
+        static function _get_debug_log() {
+            check_admin_referer( 'fs_get_debug_log' );
+
+            if ( ! is_super_admin() ) {
+                return;
+            }
+
+            if (!FS_Logger::$ON) {
+                return;
+            }
+
+            $limit  = min( ! empty( $_POST['limit'] ) ? absint( $_POST['limit'] ) : 200, 200 );
+            $offset = min( ! empty( $_POST['offset'] ) ? absint( $_POST['offset'] ) : 200, 200 );
+
+            $logs = FS_Logger::load_db_logs(
+                fs_request_get( 'filters', false, 'post' ),
+                $limit,
+                $offset
+            );
+
+            Freemius::shoot_ajax_success( $logs );
+        }
+
+        /**
+         * @author Vova Feldman (@svovaf)
+         *  Moved from Freemius
+         *
+         * @since  1.2.1.7
+         */
+        static function _get_db_option() {
+            check_admin_referer( 'fs_get_db_option' );
+
+            $option_name = fs_request_get( 'option_name' );
+
+            if ( ! is_super_admin() ||
+                 ! fs_starts_with( $option_name, 'fs_' )
+            ) {
+                Freemius::shoot_ajax_failure();
+            }
+
+            $value = get_option( $option_name );
+
+            $result = array(
+                'name' => $option_name,
+            );
+
+            if ( false !== $value ) {
+                if ( ! is_string( $value ) ) {
+                    $value = json_encode( $value );
+                }
+
+                $result['value'] = $value;
+            }
+
+            Freemius::shoot_ajax_success( $result );
+        }
+
+        /**
+         * @author Vova Feldman (@svovaf)
+         *  Moved from Freemius
+         *
+         * @since  1.2.1.7
+         */
+        static function _set_db_option() {
+            check_admin_referer( 'fs_set_db_option' );
+
+            $option_name = fs_request_get( 'option_name' );
+
+            if ( ! is_super_admin() ||
+                 ! fs_starts_with( $option_name, 'fs_' )
+            ) {
+                Freemius::shoot_ajax_failure();
+            }
+
+            $option_value = fs_request_get_raw( 'option_value' );
+
+            if ( ! empty( $option_value ) ) {
+                update_option( $option_name, $option_value );
+            }
+
+            Freemius::shoot_ajax_success();
+        }
+
+        /**
+         * @author Vova Feldman (@svovaf)
+         *  Moved from Freemius
+         *
+         * @since  1.1.7.3
+         */
+        static function _toggle_debug_mode() {
+            check_admin_referer( 'fs_toggle_debug_mode' );
+
+            if ( ! is_super_admin() ) {
+                return;
+            }
+
+            $is_on = fs_request_get( 'is_on', false, 'post' );
+
+            if ( fs_request_is_post() && in_array( $is_on, array( 0, 1 ) ) ) {
+                if ( $is_on ) {
+                    self::_turn_on_debug_mode();
+                } else {
+                    self::_turn_off_debug_mode();
+                }
+
+                // Turn on/off storage logging.
+                FS_Logger::_set_storage_logging( ( 1 == $is_on ) );
+
+                // Logic to turn debugging off automatically
+                if ( 1 == $is_on ) {
+                    // Plan a single event triggering after 24 hours to turn debugging off.
+                    wp_schedule_single_event( time() + 24 * HOUR_IN_SECONDS, 'fs_debug_turn_off_logging_hook' );
+                } else {
+                    // Cancels any planned event when debugging is turned off manually.
+                    $timestamp = wp_next_scheduled( 'fs_debug_turn_off_logging_hook' );
+                    if ( $timestamp ) {
+                        wp_unschedule_event( $timestamp, 'fs_debug_turn_off_logging_hook' );
+                    }
+                }
+            }
+
+            exit;
+        }
+
+        /**
+         * @author Daniele Alessandra (@danielealessandra)
+         * @since  2.6.2
+         *
+         */
+        static function _turn_off_debug_mode() {
+            self::update_debug_mode_option( 0 );
+            FS_Logger::_set_storage_logging( false );
+        }
+
+        /**
+         * @author Daniele Alessandra (@danielealessandra)
+         * @since  2.6.2
+         *
+         */
+        static function _turn_on_debug_mode() {
+            self::update_debug_mode_option( 1 );
+            FS_Logger::_set_storage_logging();
+        }
+
+        /**
+         * @author Leo Fajardo (@leorw)
+         *  Moved from Freemius
+         *
+         * @param string $url
+         * @param array  $request
+         *
+         * @since  2.1.0
+         *
+         */
+        public static function enrich_request_for_debug( &$url, &$request ) {
+            if ( WP_FS__DEBUG_SDK || isset( $_COOKIE['XDEBUG_SESSION'] ) ) {
+                $url = add_query_arg( 'XDEBUG_SESSION_START', rand( 0, 9999999 ), $url );
+                $url = add_query_arg( 'XDEBUG_SESSION', 'PHPSTORM', $url );
+
+                $request['cookies'] = array(
+                    new WP_Http_Cookie( array(
+                        'name'  => 'XDEBUG_SESSION',
+                        'value' => 'PHPSTORM',
+                    ) ),
+                );
+            }
+        }
+
+        /**
+         * @author Leo Fajardo (@leorw)
+         *  Moved from Freemius
+         *
+         * @return array
+         *
+         * @since  2.0.0
+         *
+         */
+        private static function get_all_licenses_by_module_type() {
+            $licenses = Freemius::get_account_option( 'all_licenses' );
+
+            $licenses_by_module_type = array(
+                WP_FS__MODULE_TYPE_PLUGIN => array(),
+                WP_FS__MODULE_TYPE_THEME  => array(),
+            );
+
+            if ( ! is_array( $licenses ) ) {
+                return $licenses_by_module_type;
+            }
+
+            foreach ( $licenses as $module_id => $module_licenses ) {
+                $fs = Freemius::get_instance_by_id( $module_id );
+                if ( false === $fs ) {
+                    continue;
+                }
+
+                $licenses_by_module_type[ $fs->get_module_type() ] = array_merge( $licenses_by_module_type[ $fs->get_module_type() ],
+                    $module_licenses );
+            }
+
+            return $licenses_by_module_type;
+        }
+
+        /**
+         * @author Leo Fajardo (@leorw)
+         *  Moved from Freemius
+         *
+         * @return array
+         *
+         * @since  2.5.0
+         *
+         */
+        static function get_all_modules_sites() {
+            Freemius::get_static_logger()->entrance();
+
+            $sites_by_type = array(
+                WP_FS__MODULE_TYPE_PLUGIN => array(),
+                WP_FS__MODULE_TYPE_THEME  => array(),
+            );
+
+            $module_types = array_keys( $sites_by_type );
+
+            if ( ! is_multisite() ) {
+                foreach ( $module_types as $type ) {
+                    $sites_by_type[ $type ] = Freemius::get_all_sites( $type );
+
+                    foreach ( $sites_by_type[ $type ] as $slug => $install ) {
+                        $sites_by_type[ $type ][ $slug ] = array( $install );
+                    }
+                }
+            } else {
+                $sites = Freemius::get_sites();
+
+                foreach ( $sites as $site ) {
+                    $blog_id = Freemius::get_site_blog_id( $site );
+
+                    foreach ( $module_types as $type ) {
+                        $installs = Freemius::get_all_sites( $type, $blog_id );
+
+                        foreach ( $installs as $slug => $install ) {
+                            if ( ! isset( $sites_by_type[ $type ][ $slug ] ) ) {
+                                $sites_by_type[ $type ][ $slug ] = array();
+                            }
+
+                            $install->blog_id = $blog_id;
+
+                            $sites_by_type[ $type ][ $slug ][] = $install;
+                        }
+                    }
+                }
+            }
+
+            return $sites_by_type;
+        }
+
+        /**
+         * Delete user.
+         *
+         * @author Vova Feldman (@svovaf)
+         *
+         * @param number $user_id
+         * @param bool   $store
+         *
+         * @return false|int The user ID if deleted. Otherwise, FALSE (when install not exist).
+         * @since  2.0.0
+         *
+         */
+        public static function delete_user( $user_id, $store = true ) {
+            $users = Freemius::get_all_users();
+
+            if ( ! is_array( $users ) || ! isset( $users[ $user_id ] ) ) {
+                return false;
+            }
+
+            unset( $users[ $user_id ] );
+
+            self::$_accounts->set_option( 'users', $users, $store );
+
+            return $user_id;
+        }
+
+        /**
+         * @author Daniele Alessandra (@danielealessandra)
+         *
+         * @return void
+         * @since  2.6.2
+         *
+         */
+        public static function load_required_static() {
+            if ( ! WP_FS__DEMO_MODE ) {
+                add_action( ( fs_is_network_admin() ? 'network_' : '' ) . 'admin_menu', array(
+                    self::class,
+                    '_add_debug_section',
+                ) );
+            }
+
+            add_action( "wp_ajax_fs_toggle_debug_mode", array( self::class, '_toggle_debug_mode' ) );
+
+            Freemius::add_ajax_action_static( 'get_debug_log', array( self::class, '_get_debug_log' ) );
+            Freemius::add_ajax_action_static( 'get_db_option', array( self::class, '_get_db_option' ) );
+            Freemius::add_ajax_action_static( 'set_db_option', array( self::class, '_set_db_option' ) );
+        }
+
+        /**
+         * @author Daniele Alessandra (@danielealessandra)
+         *
+         * @return void
+         *
+         * @since  2.6.2
+         */
+        public static function register_hooks() {
+            add_action( 'fs_debug_turn_off_logging_hook', array( self::class, '_turn_off_debug_mode' ) );
+        }
+
+        /**
+         * @author Daniele Alessandra (@danielealessandra)
+         *
+         * @param int $is_on
+         *
+         * @return void
+         *
+         * @since  2.6.2
+         */
+        private static function update_debug_mode_option( $is_on ) {
+            update_option( 'fs_debug_mode', $is_on );
+        }
+
+    }

--- a/includes/managers/class-fs-debug-manager.php
+++ b/includes/managers/class-fs-debug-manager.php
@@ -287,9 +287,6 @@
                     self::_turn_off_debug_mode();
                 }
 
-                // Turn on/off storage logging.
-                FS_Logger::_set_storage_logging( ( 1 == $is_on ) );
-
                 // Logic to turn debugging off automatically
                 if ( 1 == $is_on ) {
                     // Plan a single event triggering after 24 hours to turn debugging off.

--- a/includes/managers/class-fs-debug-manager.php
+++ b/includes/managers/class-fs-debug-manager.php
@@ -189,7 +189,7 @@
                 return;
             }
 
-            if (!FS_Logger::$ON) {
+            if (!FS_Logger::is_storage_logging_on()) {
                 return;
             }
 

--- a/require.php
+++ b/require.php
@@ -50,6 +50,7 @@
 	require_once WP_FS__DIR_INCLUDES . '/class-fs-api.php';
 	require_once WP_FS__DIR_INCLUDES . '/class-fs-plugin-updater.php';
 	require_once WP_FS__DIR_INCLUDES . '/class-fs-security.php';
+	require_once WP_FS__DIR_INCLUDES . '/managers/class-fs-debug-manager.php';
     require_once WP_FS__DIR_INCLUDES . '/class-fs-options.php';
     require_once WP_FS__DIR_INCLUDES . '/class-fs-storage.php';
     require_once WP_FS__DIR_INCLUDES . '/class-fs-admin-notices.php';

--- a/templates/debug.php
+++ b/templates/debug.php
@@ -17,6 +17,9 @@
     $off_text = fs_text_x_inline( 'Off', 'as turned off' );
     $on_text  = fs_text_x_inline( 'On', 'as turned on' );
 
+    // For some reason css was missing
+    fs_enqueue_local_style( 'fs_common', '/admin/common.css' );
+
     $has_any_active_clone = false;
 
     $is_multisite = is_multisite();

--- a/templates/debug.php
+++ b/templates/debug.php
@@ -20,16 +20,20 @@
     $has_any_active_clone = false;
 
     $is_multisite = is_multisite();
+
+    $auto_off_timestamp = wp_next_scheduled( 'fs_debug_turn_off_logging_hook' ) * 1000;
 ?>
 <h1><?php echo fs_text_inline( 'Freemius Debug' ) . ' - ' . fs_text_inline( 'SDK' ) . ' v.' . $fs_active_plugins->newest->version ?></h1>
 <div>
     <!-- Debugging Switch -->
-    <?php //$debug_mode = get_option( 'fs_debug_mode', null ) ?>
     <span class="fs-switch-label"><?php fs_esc_html_echo_x_inline( 'Debugging', 'as code debugging' ) ?></span>
 
     <div class="fs-switch fs-round <?php echo WP_FS__DEBUG_SDK ? 'fs-on' : 'fs-off' ?>">
         <div class="fs-toggle"></div>
     </div>
+
+    <span class="auto-off-debug-countdown hidden"><?php echo fs_esc_html_echo_x_inline( 'Auto off in:', 'timer for auto-disabling debug' ); ?> <span class="time">23:59:59</span>
+
     <script type="text/javascript">
         (function ($) {
             $(document).ready(function () {
@@ -39,18 +43,70 @@
                         .toggleClass( 'fs-on' )
                         .toggleClass( 'fs-off' );
 
+                    var is_on = ($(this).hasClass( 'fs-on' ) ? 1 : 0);
+
                     $.post( <?php echo Freemius::ajax_url() ?>, {
                         action: 'fs_toggle_debug_mode',
                         // As such we don't need to use `wp_json_encode` method but using it to follow wp.org guideline.
                         _wpnonce   : <?php echo wp_json_encode( wp_create_nonce( 'fs_toggle_debug_mode' ) ); ?>,
-                        is_on : ($(this).hasClass( 'fs-on' ) ? 1 : 0)
-                    }, function ( response ) {
+                        is_on
+                    }, function (response) {
+                        if (is_on) {
+                            startCountdownManually();
+                        } else {
+                            stopCountdownManually();
+                        }
+
                         if ( 1 == response ) {
                             // Refresh page on success.
                             location.reload();
                         }
                     });
                 });
+
+                // Countdown
+                var countdownElement = document.querySelector('.auto-off-debug-countdown');
+                var timeElement = countdownElement.querySelector('.time');
+                var targetTime = <?php echo wp_json_encode( $auto_off_timestamp ); ?>;
+                var countdownTimeout;
+
+                function updateCountdown() {
+                    var currentTime = new Date().getTime();
+                    var remainingTimeInMs = targetTime - currentTime;
+                    var hours = Math.floor((remainingTimeInMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+                    var minutes = Math.floor((remainingTimeInMs % (1000 * 60 * 60)) / (1000 * 60));
+                    var seconds = Math.floor((remainingTimeInMs % (1000 * 60)) / 1000);
+
+
+                    if (remainingTimeInMs < 1000) {
+                        countdownElement.classList.add('hidden');
+                        countdownTimeout = null;
+                    } else {
+                        timeElement.innerHTML = hours + ":"
+                            + minutes.toString().padStart(2, '0') + ":"
+                            + seconds.toString().padStart(2, '0');
+                        countdownElement.classList.remove('hidden');
+
+                        if (countdownTimeout) {
+                            clearTimeout(countdownTimeout);
+                        }
+                        countdownTimeout = setTimeout(updateCountdown, 1000);
+                    }
+                }
+
+                function startCountdownManually() {
+                    targetTime = ( new Date().getTime() ) + (24 * 60 * 60 * 1000) - 1;
+                    updateCountdown();
+                }
+
+                function stopCountdownManually() {
+                    targetTime = new Date().getTime();
+                    updateCountdown();
+                }
+
+                updateCountdown();
+                // End countdown
+
             });
         }(jQuery));
     </script>


### PR DESCRIPTION
When the user activates debugging a single event cron starts:
`wp_schedule_single_event(time() + 24 * HOUR_IN_SECONDS, 'fs_debug_turn_off_logging_hook');`

When the user deactivates debuggong this cron is unscheduled:
`wp_unschedule_event($timestamp, 'fs_debug_turn_off_logging_hook');`

If the event happens, the option is set to off:
`add_action('fs_debug_turn_off_logging_hook', array( self::class, '_turn_off_debug_mode' ) );`

Also, in the debug page I added a countdown timer, so the user is informed about the fact that debugging will be disabled automatically.
![image](https://github.com/Freemius/wordpress-sdk/assets/4690419/ab43a5c9-c653-4d11-b0ba-bd6d725d24f2)
