### PR TITLE
[cleanup] Remove unused mixins from the codebase

### DIFF
--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -22,15 +22,6 @@
 //  THE SOFTWARE.
 //
 
-// ---- LEGACY IE SUPPORT USING FILTERS ----
-//  Should IE filters be used or not?
-//  PROS: gradients, drop shadows etc will be handled by css.
-//  CONS: will harm the site performance badly, 
-//        especially on sites with heavy rendering and scripting. 
-$useIEFilters: 0; 
-// might be 0 or 1. disabled by default.
-// ---- /LEGACY IE SUPPORT USING FILTERS ----
-
 // requires sass 3.2
 @mixin keyframes($name){
      @-moz-keyframes #{$name} { @content; }
@@ -41,11 +32,7 @@ $useIEFilters: 0;
 }
 
 @mixin transform($transforms) {
-	   -moz-transform: $transforms;
-	     -o-transform: $transforms;
-	    -ms-transform: $transforms;
-	-webkit-transform: $transforms;
-          transform: $transforms;
+  transform: $transforms;
 }
 
 @mixin rotate($deg) {
@@ -72,11 +59,7 @@ $useIEFilters: 0;
 
 // Placeholder text
 @mixin placeholder($color: $input-color-placeholder) {
-    // Firefox
-    &::-moz-placeholder {
+    &::placeholder {
         color: $color;
-        opacity: 1; // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526
     }
-    &:-ms-input-placeholder { color: $color; } // Internet Explorer 10+
-    &::-webkit-input-placeholder  { color: $color; } // Safari and Chrome
 }

--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -31,52 +31,6 @@ $useIEFilters: 0;
 // might be 0 or 1. disabled by default.
 // ---- /LEGACY IE SUPPORT USING FILTERS ----
 
-
-@mixin background-size ($value) {
-  -webkit-background-size: $value;
-          background-size: $value;
-}
-
-@mixin border-image ($path, $offsets, $repeats) {
-     -moz-border-image: $path $offsets $repeats;
-       -o-border-image: $path $offsets $repeats;
-  -webkit-border-image: $path $offsets $repeats;
-          border-image: $path $offsets $repeats;
-}
-
-@mixin border-radius ($values...) {
-     -moz-border-radius: $values;
-  -webkit-border-radius: $values;
-          border-radius: $values;
-             /*-moz-background-clip: padding; 
-          -webkit-background-clip: padding-box; 
-                  background-clip: padding-box;*/
-}
-
-@mixin box-shadow ($values...) {
-     -moz-box-shadow: $values;
-  -webkit-box-shadow: $values;
-          box-shadow: $values;
-}
-
-//@mixin box-shadow ($x, $y, $offset, $hex, $ie: $useIEFilters, $inset: null, $spread:null) {
-//     -moz-box-shadow: $x $y $offset $spread $hex $inset;
-//  -webkit-box-shadow: $x $y $offset $spread $hex $inset;
-//          box-shadow: $x $y $offset $spread $hex $inset;
-//  
-//  @if $ie == 1 {
-//    $iecolor: '#' + red($hex) + green($hex) + blue($hex);
-//    filter: progid:DXImageTransform.Microsoft.dropshadow(OffX=#{$x}, OffY=#{$y}, Color='#{$iecolor}');
-//    -ms-filter: quote(progid:DXImageTransform.Microsoft.dropshadow(OffX=#{$x}, OffY=#{$y}, Color='#{$iecolor}'));
-//  }
-//}
-
-@mixin box-sizing($value) {
-     -moz-box-sizing: $value;
-  -webkit-box-sizing: $value;
-          box-sizing: $value;
-}
-
 // requires sass 3.2
 @mixin keyframes($name){
      @-moz-keyframes #{$name} { @content; }
@@ -86,64 +40,7 @@ $useIEFilters: 0;
           @keyframes #{$name} { @content; }
 }
 
-@mixin linear-gradient($from, $to, $ie: $useIEFilters) {
-  @if $ie != 1 { background-color: $to; }
-  
-  background-image: -webkit-gradient(linear,left top,left bottom,color-stop(0, $from),color-stop(1, $to));
-  background-image: -webkit-linear-gradient(top, $from, $to);
-  background-image: -moz-linear-gradient(top, $from, $to);
-  background-image: -ms-linear-gradient(top, $from, $to);
-  background-image: -o-linear-gradient(top, $from, $to);
-  background-image: linear-gradient(top, bottom, $from, $to);
-
-  @if $ie == 1 { 
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$from}', endColorstr='#{$to}');
-  }
-}
-
-@mixin horizontal-gradient($startColor: #555, $endColor: #333, $ie: $useIEFilters) {
-	@if $ie != 1 { background-color: $endColor; }
-
-	background-color: $endColor;
-	background-image: -webkit-gradient(linear, 0 0, 100% 0, from($startColor), to($endColor)); // Safari 4+, Chrome 2+
-	background-image: -webkit-linear-gradient(left, $startColor, $endColor); // Safari 5.1+, Chrome 10+
-	background-image: -moz-linear-gradient(left, $startColor, $endColor); // FF 3.6+
-	background-image: -o-linear-gradient(left, $startColor, $endColor); // Opera 11.10
-	background-image: linear-gradient(to right, $startColor, $endColor); // Standard, IE10
-	background-repeat: repeat-x;
-	@if $ie == 1 { 
-		filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$startColor}', endColorstr='#{$endColor}', GradientType=1);
-	}
-}
-
-@mixin radial-gradient($from, $to, $ie: $useIEFilters) {
-    @if $ie != 1 { background-color: $to; }
-
-    background: -moz-radial-gradient(center, circle cover, $from 0%, $to 100%);
-    background: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop(0%, $from), color-stop(100%, $to));
-    background: -webkit-radial-gradient(center, circle cover, $from 0%, $to 100%);
-    background: -o-radial-gradient(center, circle cover, $from 0%, $to 100%);
-    background: -ms-radial-gradient(center, circle cover, $from 0%, $to 100%);
-    background: radial-gradient(center, circle cover, $from 0%, $to 100%);
-    background-color: $from;
-
-    @if $ie == 1 {
-        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$from}', endColorstr='#{$to}', GradientType=1); /* IE6-9 fallback on horizontal gradient */
-    }
-}
-
-@mixin perspective($perspective) {
-     -moz-perspective: $perspective;
-      -ms-perspective: $perspective;
-  -webkit-perspective: $perspective;
-          perspective: $perspective;
-     -moz-transform-style: preserve-3d;
-      -ms-transform-style: preserve-3d;
-  -webkit-transform-style: preserve-3d;
-          transform-style: preserve-3d;
-}
-
-@mixin transform ($transforms) {
+@mixin transform($transforms) {
 	   -moz-transform: $transforms;
 	     -o-transform: $transforms;
 	    -ms-transform: $transforms;
@@ -151,104 +48,19 @@ $useIEFilters: 0;
           transform: $transforms;
 }
 
-    @mixin matrix ($a, $b, $c, $d, $e, $f) {
-    	   -moz-transform: matrix($a, $b, $c, $d, #{$e}px, #{$f}px);
-    	     -o-transform: matrix($a, $b, $c, $d, $e, $f);
-    	    -ms-transform: matrix($a, $b, $c, $d, $e, $f);
-    	-webkit-transform: matrix($a, $b, $c, $d, $e, $f);
-              transform: matrix($a, $b, $c, $d, $e, $f);
-    }
-
-    @mixin rotate ($deg) {
-      @include transform(rotate(#{$deg}deg));
-    }
-
-    @mixin scale ($size) {
-      @include transform(scale(#{$size}));
-    }
-
-    @mixin translate ($x, $y) {
-    	@include transform(translate($x, $y));
-    }
-
-@mixin transition ($value...) {
-     -moz-transition: $value;
-       -o-transition: $value;
-      -ms-transition: $value;
-  -webkit-transition: $value;
-          transition: $value;
+@mixin rotate($deg) {
+  @include transform(rotate(#{$deg}deg));
 }
 
-@mixin animation($str) {
-    -webkit-animation: #{$str};
-    -moz-animation: #{$str};
-    -ms-animation: #{$str};
-    -o-animation: #{$str};
-    animation: #{$str};
+@mixin scale($size) {
+  @include transform(scale(#{$size}));
 }
 
-@mixin animation-name($str) {
-    -webkit-animation-name: #{$str};
-    -moz-animation-name: #{$str};
-    -ms-animation-name: #{$str};
-    -o-animation-name: #{$str};
-    animation-name: #{$str};
-}
-
-@mixin animation-duration($str) {
-    -webkit-animation-duration: #{$str};
-    -moz-animation-duration: #{$str};
-    -ms-animation-duration: #{$str};
-    -o-animation-duration: #{$str};
-    animation-duration: #{$str};
-}
-
-@mixin animation-direction($str) {
-    -webkit-animation-direction: #{$str};
-    -moz-animation-direction: #{$str};
-    -ms-animation-direction: #{$str};
-    -o-animation-direction: #{$str};
-    animation-direction: #{$str};
-}
-
-@mixin animation-delay($str) {
-    animation-delay:#{$str};
-    -o-animation-delay:#{$str};
-    -ms-animation-delay:#{$str};
-    -webkit-animation-delay:#{$str};
-    -moz-animation-delay:#{$str};
-}
-
-@mixin animation-iteration-count($str) {
-    animation-iteration-count:#{$str};
-    -o-animation-iteration-count:#{$str};
-    -ms-animation-iteration-count:#{$str};
-    -webkit-animation-iteration-count:#{$str};
-    -moz-animation-iteration-count:#{$str};
-}
-
-@mixin animation-timing-function($str) {
-    -webkit-animation-timing-function: #{$str};
-    -moz-animation-timing-function: #{$str};
-    -ms-animation-timing-function: #{$str};
-    -o-animation-timing-function: #{$str};
-    animation-timing-function: #{$str};
+@mixin translate($x, $y) {
+    @include transform(translate($x, $y));
 }
 
 // ==== /CSS3 SASS MIXINS ====
-
-@mixin opacity($opacity) {
-    opacity: $opacity;
-    $opacity-ie: $opacity * 100;
-    filter: alpha(opacity=$opacity-ie); //IE8
-}
-
-@mixin size($width, $height: $width)
-{
-    width: $width;
-    height: $height;
-}
-
 @mixin clearfix
 {
     &:after {

--- a/assets/scss/admin/_ajax-loader.scss
+++ b/assets/scss/admin/_ajax-loader.scss
@@ -20,7 +20,7 @@ $size: 20;
         animation-duration: 1.5s;
         animation-iteration-count: infinite;
         animation-direction: normal;
-        @include transform(.3);
+        @include transform(scale(.3));
     }
 
     @for $i from 0 through 7

--- a/assets/scss/admin/_ajax-loader.scss
+++ b/assets/scss/admin/_ajax-loader.scss
@@ -16,10 +16,10 @@ $size: 20;
         background-color: $color;
         width:            #{$size}px;
         height:           #{$size}px;
-        @include animation-name(bounce_ajaxLoader);
-        @include animation-duration(1.5s);
-        @include animation-iteration-count(infinite);
-        @include animation-direction(normal);
+        animation-name: bounce_ajaxLoader;
+        animation-duration: 1.5s;
+        animation-iteration-count: infinite;
+        animation-direction: normal;
         @include transform(.3);
     }
 
@@ -28,7 +28,7 @@ $size: 20;
         .fs-ajax-loader-bar-#{$i + 1}
         {
             left: #{$i*($size - 1)}px;
-            @include animation-delay(#{0.6 + $i*0.15}s);
+            animation-delay: #{0.6 + $i*0.15}s;
         }
     }
 }

--- a/assets/scss/admin/_badge.scss
+++ b/assets/scss/admin/_badge.scss
@@ -7,8 +7,8 @@
     color:          white;
     text-transform: uppercase;
     padding:        5px 10px;
-    @include border-radius(3px 0 0 3px);
+    border-radius:  3px 0 0 3px;
     font-weight:    bold;
     border-right:   0;
-    @include box-shadow(0 2px 1px -1px rgba(0, 0, 0, .3));
+    box-shadow:     0 2px 1px -1px rgba(0, 0, 0, .3);
 }

--- a/assets/scss/admin/_modal-common.scss
+++ b/assets/scss/admin/_modal-common.scss
@@ -124,9 +124,9 @@
             top: 12px;
             cursor: pointer;
             color: #bbb;
-            @include border-radius(20px);
+            border-radius: 20px;
             padding: 3px;
-            @include transition(all 0.2s ease-in-out);
+			transition: all 0.2s ease-in-out;
 
             &:hover {
                 color: #fff;

--- a/assets/scss/admin/_modal-common.scss
+++ b/assets/scss/admin/_modal-common.scss
@@ -126,7 +126,7 @@
             color: #bbb;
             border-radius: 20px;
             padding: 3px;
-			transition: all 0.2s ease-in-out;
+            transition: all 0.2s ease-in-out;
 
             &:hover {
                 color: #fff;

--- a/assets/scss/admin/_switch.scss
+++ b/assets/scss/admin/_switch.scss
@@ -40,7 +40,7 @@ $switch-on-color: $wp-button-primary-background-color;
         background-image: linear-gradient(to bottom, #ececec, #fff);
         box-shadow:    inset 0 1px 0 0 rgba(255, 255, 255, 0.5);
         z-index:       999;
-        @include transition(0.40s cubic-bezier(0.54, 1.6, 0.5, 1));
+        transition: 0.40s cubic-bezier(0.54, 1.6, 0.5, 1);
     }
 
     &.fs-off .fs-toggle
@@ -57,14 +57,14 @@ $switch-on-color: $wp-button-primary-background-color;
     {
         top:     math.div($switch-size, 3);
         padding: 4px ($switch-size + 1px);
-        @include border-radius($switch-size);
+        border-radius: $switch-size;
 
         .fs-toggle
         {
             top:    0;
             width:  $switch-size;
             height: $switch-size;
-            @include border-radius($switch-size);
+            border-radius: $switch-size;
         }
 
         &.fs-off .fs-toggle
@@ -94,7 +94,7 @@ $switch-on-color: $wp-button-primary-background-color;
                 top:    0;
                 width:  $switch-small-size;
                 height: $switch-small-size;
-                @include border-radius($switch-small-size);
+                border-radius: $switch-small-size;
             }
 
             &.fs-on .fs-toggle

--- a/assets/scss/admin/_tooltip.scss
+++ b/assets/scss/admin/_tooltip.scss
@@ -17,7 +17,7 @@
     {
         opacity:       0;
         visibility:    hidden;
-        @include transition(opacity 0.3s ease-in-out);
+        transition:    opacity 0.3s ease-in-out;
         position:      absolute;
         background:    $tooltip-bkg-color;
         color:         $tooltip-color !important;
@@ -29,8 +29,8 @@
         margin-bottom: 5px;
         left:          -17px;
         right:         0;
-        @include border-radius(5px);
-        @include box-shadow(1px 1px 1px rgba(0, 0, 0, 0.2));
+        border-radius: 5px;
+        box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
         line-height:   1.3em;
         font-weight:   bold;
         text-align:    left;

--- a/assets/scss/admin/add-ons.scss
+++ b/assets/scss/admin/add-ons.scss
@@ -40,7 +40,7 @@
 
                 & > ul
                 {
-                    @include transition(all, 0.15s);
+                    transition: all, 0.15s;
                     left:     0;
                     right:    0;
                     top:      0;
@@ -53,7 +53,7 @@
                         padding:     0 15px;
                         width:       100%;
                         display:     block;
-                        @include box-sizing(border-box);
+                        box-sizing: border-box;
                     }
                 }
 
@@ -66,7 +66,7 @@
                     height:            100px;
                     background-repeat: repeat-x;
                     background-size:   100% 100%;
-                    @include transition(all, 0.15s);
+                    transition:        all, 0.15s;
 
                     .fs-badge.fs-installed-addon-badge {
                         font-size:      1.02em;
@@ -107,7 +107,7 @@
                     background: greenyellow;
                     display: block;
                     padding: 2px 10px;
-                    @include box-shadow(1px 1px 1px rgba(0,0,0,0.3));
+                    box-shadow: 1px 1px 1px rgba(0,0,0,0.3);
                     text-transform: uppercase;
                     font-size: 0.9em;
                     font-weight: bold;
@@ -235,7 +235,7 @@
                     height:        225px;
                     float:         left;
                     margin-bottom: 20px;
-                    @include box-sizing(content-box);
+                    box-sizing: content-box;
 
                     a
                     {
@@ -243,7 +243,7 @@
                         width:           100%;
                         height:          100%;
                         border:          1px solid;
-                        @include box-shadow(1px 1px 1px rgba(0, 0, 0, 0.2));
+                        box-shadow:      1px 1px 1px rgba(0, 0, 0, 0.2);
                         background-size: cover;
                     }
 
@@ -509,7 +509,7 @@
       z-index: 1;
       width: 230px;
       text-align: left;
-      @include box-shadow(0px 2px 4px -1px rgba(0, 0, 0, 0.2), 0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12));
+      box-shadow: 0px 2px 4px -1px rgba(0, 0, 0, 0.2), 0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12);
 
       li {
         margin: 0;
@@ -534,13 +534,13 @@
 
     &:not(.up) {
       .fs-dropdown-list {
-        @include border-radius(3px 0 3px 3px);
+        border-radius: 3px 0 3px 3px;
       }
     }
 
     &.up {
       .fs-dropdown-list {
-        @include border-radius(3px 3px 0 3px);
+        border-radius: 3px 3px 0 3px;
       }
     }
   }

--- a/assets/scss/admin/affiliation.scss
+++ b/assets/scss/admin/affiliation.scss
@@ -13,7 +13,7 @@
 
   ul {
     li {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       list-style-type: none;
 
       &:before {

--- a/assets/scss/admin/common.scss
+++ b/assets/scss/admin/common.scss
@@ -85,7 +85,7 @@ body.fs-loading {
         top:         100%;
         bottom:      auto;
         right:       auto;
-        @include border-radius(0 0 3px 3px);
+        border-radius: 0 0 3px 3px;
         left:        10px;
         font-size:   12px;
         font-weight: bold;
@@ -152,12 +152,12 @@ div.fs-notice
     padding:    10px 20px;
     color:      green;
     z-index:    9999;
-    @include box-shadow(0 2px 2px rgba(6, 113, 6, 0.3));
-    @include opacity(0.95);
+    box-shadow: 0 2px 2px rgba(6, 113, 6, 0.3);
+    opacity: 0.95;
 
     &:hover
     {
-        @include opacity(1);
+        opacity: 1;
     }
 
     a.fs-security-proof

--- a/assets/scss/admin/connect.scss
+++ b/assets/scss/admin/connect.scss
@@ -36,7 +36,7 @@ $box_border_radius: 3px;
         margin:                   30px 0 0 -10px;
 
         .fs-box-container {
-            @include box-shadow(none);
+            box-shadow: none;
         }
     }
 
@@ -50,7 +50,7 @@ $box_border_radius: 3px;
             background: snow;
             color: $fs-logo-magenta-color;
             border: 1px solid $fs-logo-magenta-color;
-            @include box-shadow(0 1px 1px 0 rgba(0,0,0,.1));
+            box-shadow: 0 1px 1px 0 rgba(0,0,0,.1);
             text-align: center;
             padding: 5px;
             margin-bottom: 10px;
@@ -188,7 +188,7 @@ $box_border_radius: 3px;
     {
         padding:    10px 20px;
         background: #fff;
-        @include transition(background 0.5s ease);
+        transition: background 0.5s ease;
 
         .fs-license-sync-disclaimer {
             text-align: center;
@@ -492,7 +492,7 @@ $box_border_radius: 3px;
     #fs_connect
     {
         margin: 0;
-        @include box-shadow(none);
+        box-shadow: none;
     }
 }
 

--- a/assets/scss/customizer.scss
+++ b/assets/scss/customizer.scss
@@ -45,7 +45,7 @@
         .fs-feature-desc {
             opacity:       0;
             visibility: hidden;
-            @include transition(opacity 0.3s ease-in-out);
+            transition: opacity 0.3s ease-in-out;
 
             position:      absolute;
             background:    $tooltip-color;
@@ -58,8 +58,8 @@
             margin-bottom: 5px;
             left:          0;
             right:         0;
-            @include border-radius(5px);
-            @include box-shadow(1px 1px 1px rgba(0,0,0,0.2));
+            border-radius: 5px;
+            box-shadow:    1px 1px 1px rgba(0,0,0,0.2);
             line-height:   1.3em;
             font-weight:   bold;
             text-align:    left;

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.7.3.4';
+	$this_sdk_version = '2.7.3.5';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
- [x] Remove unused mixins from the codebase.
- [x] Use the autoprefixer in the build process. Remove mixins made obsolute. We have an autoprefixer which makes the build process more efficient in managing future browser support and deprecations.