### PR TITLE
[trial] [dialog] Fixes trial activation button layout

### DIFF
--- a/assets/scss/admin/common.scss
+++ b/assets/scss/admin/common.scss
@@ -48,6 +48,14 @@ body.fs-loading {
     {
         margin:  .5em 0;
         padding: 2px;
+
+        .fs-trial-message-container
+        {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 5px;
+        }
     }
 
     .fs-close

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -24000,13 +24000,15 @@
 
             // Start trial button.
             $button = ' ' . sprintf(
-                    '<a style="margin-left: 10px; vertical-align: super;" href="%s"><button class="button button-primary">%s &nbsp;&#10140;</button></a>',
+                    '<div><a class="button button-primary" href="%s">%s &nbsp;&#10140;</a></div>',
                     $trial_url,
                     $this->get_text_x_inline( 'Start free trial', 'call to action', 'start-free-trial' )
                 );
 
+            $message_text = $this->apply_filters( 'trial_promotion_message', "{$message} {$cc_string}" );
+
             $this->_admin_notices->add_sticky(
-                $this->apply_filters( 'trial_promotion_message', "{$message} {$cc_string} {$button}" ),
+                "<div class=\"fs-trial-message-container\"><div>{$message_text}</div> {$button}</div>",
                 'trial_promotion',
                 '',
                 'promotion'

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.10.0.2';
+	$this_sdk_version = '2.10.0.3';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
Added a `display:flex` container to keep text and button separate and consistent in different screen sizes