### PR TITLE
Add `autocomplete="off"` to a search field to prevent browsers from a…

### DIFF
--- a/templates/account.php
+++ b/templates/account.php
@@ -723,7 +723,7 @@
                                         <a class="button<?php echo ( ! $has_license ? ' button-primary' : '' ) ?> activate-license-trigger <?php echo $fs->get_unique_affix() ?>" href="#"><?php echo $activate_license_button_text ?></a>
                                     <?php endif ?>
                                 <?php endif ?>
-								<input class="fs-search" type="text" placeholder="<?php fs_esc_attr_echo_inline( 'Search by address', 'search-by-address', $slug ) ?>..."><span class="dashicons dashicons-search"></span>
+								<input class="fs-search" type="text" placeholder="<?php fs_esc_attr_echo_inline( 'Search by address', 'search-by-address', $slug ) ?>..." autocomplete="off"><span class="dashicons dashicons-search"></span>
 							</div>
 							<div class="inside">
                                 <div id="" class="fs-scrollable-table">


### PR DESCRIPTION
…uto-filling it.

I have had users report issues with their browser auto-filling e.g. their names into this field. This then causes problems due to the JS handling of the input data.
As searching for a site should never need personal user data, turning off browser auto-completion makes sense here.