### PR TITLE
Fix bug with notice bar covering menu

### DIFF
--- a/assets/scss/admin/common.scss
+++ b/assets/scss/admin/common.scss
@@ -151,7 +151,7 @@ div.fs-notice
     background: rgb(235, 253, 235);
     padding:    10px 20px;
     color:      green;
-    z-index:    9999;
+    z-index:    9989; // 1 less than WordPress' #adminmenuwrap
     box-shadow: 0 2px 2px rgba(6, 113, 6, 0.3);
     opacity: 0.95;
 


### PR DESCRIPTION
Set z-index of `.fs-secure-notice` to 9989 in order to avoid covering `#adminmenuwrap` that has z-index: 9990