### PR TITLE
Add type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Freemius WordPress SDK",
     "keywords": ["freemius", "wordpress", "plugin", "wordpress-plugin", "theme", "wordpress-theme", "sdk"],
     "homepage": "https://freemius.com",
+    "type": "library",
     "license": "GPL-3.0-only",
     "scripts": {
         "phpcs": ["Composer\\Config::disableProcessTimeout", "phpcs -p -s --colors"],


### PR DESCRIPTION
It would allow the `composer/installers` to install the package to a directory other than the default `vendor` directory.

