### PR TITLE
Fix: Prevent SDK from exiting in CLI environments

### DIFF
--- a/start.php
+++ b/start.php
@@ -7,7 +7,7 @@
 	 */
 
 	if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+		return;
 	}
 
 	/**
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.11.0.1';
+	$this_sdk_version = '2.11.0.2';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
Changed `exit;` to `return;` in `start.php` to prevent the Freemius SDK from terminating execution in CLI environments where `ABSPATH` is not defined. This resolves conflicts with tools like PHPCS, PHPStan, and PHPUnit while ensuring the SDK remains functional within WordPress.