### PR TITLE
Fix PHP Notice from SDK when coming from `accounts/partials/addon.php`

### DIFF
--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.11.0.1';
+	$this_sdk_version = '2.11.0.2';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/templates/account/partials/addon.php
+++ b/templates/account/partials/addon.php
@@ -19,7 +19,7 @@
 
     $addon_info         = $VARS['addon_info'];
     $is_addon_activated = $fs->is_addon_activated( $addon_id );
-    $is_addon_connected = $addon_info['is_connected'];
+    $is_addon_connected = $addon_info['is_connected'] ?? false;
     $is_addon_installed = $VARS['is_addon_installed'];
 
     $fs_addon = ( $is_addon_connected && $is_addon_installed ) ?
@@ -150,7 +150,7 @@
 } ?>>
     <td>
         <!-- Title -->
-        <?php echo $addon_info['title'] ?>
+	    <?php echo $addon_info['title'] ?? '' ?>
     </td>
     <?php if ( $is_addon_connected ) : ?>
         <!-- ID -->


### PR DESCRIPTION
Add null coalescing operator to check if `is_connected` and `title` properties exist in `$addon_info