### PR TITLE
Always hook the data sync cron event callback

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -4495,9 +4495,9 @@
             }
 
             if ( $this->has_api_connectivity() ) {
-                if ( self::is_cron() ) {
-                    $this->hook_callback_to_sync_cron();
-                } else if ( $this->is_user_in_admin() ) {
+                $this->hook_callback_to_sync_cron();
+
+                if ( $this->is_user_in_admin() ) {
                     /**
                      * Schedule daily data sync cron if:
                      *


### PR DESCRIPTION
Currently the cron event callback to sync data is only hooked when the cron runner is actually running. This causes a few problems:

* A cron management plugin such as WP Crontrol will flag the event as having no action.
* Using an alternative cron runner such as Cavalcade or Cron Control will result in the action firing but the callback not being hooked. The callback will never get called.

There is no need to conditionally hook the cron event callback only when cron is running. This fixes that.

## Before

![2025-03-06-13 35 49](https://github.com/user-attachments/assets/0f3a978b-3f58-4272-94ee-5749425033c5)

## After

![2025-03-06-13 35 30](https://github.com/user-attachments/assets/29923551-5d70-4856-8645-5fc9b801d102)
