### PR TITLE
Version 2.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ if ( ! function_exists( 'my_prefix_fs' ) ) {
 
 ## Usage example
 
-You can call anySDK methods by prefixing them with the shortcode function for your particular plugin/theme (specified when completing the SDK integration form in the Developer Dashboard):
+You can call any SDK methods by prefixing them with the shortcode function for your particular plugin/theme (specified when completing the SDK integration form in the Developer Dashboard):
 
 ```php
 <?php my_prefix_fs()->get_upgrade_url(); ?>
@@ -110,9 +110,9 @@ Or when calling Freemius multiple times in a scope, it's recommended to use it w
 
 There are many other SDK methods available that you can use to enhance the functionality of your WordPress product. Some of the more common use-cases are covered in the [Freemius SDK Gists](https://freemius.com/help/documentation/wordpress-sdk/gists/) documentation.
 
-## Adding license based logic examples
+## Adding license-based logic examples
 
-Add marketing content to encourage your users to upgrade for your paid version:
+Add marketing content that encourages your users to upgrade to a paid version:
 
 ```php
 <?php
@@ -139,7 +139,7 @@ Add logic which will only be available in your premium plugin version:
 ?>
 ```
 
-To add a function which will only be available in your premium plugin version, simply add __premium_only as the suffix of the function name. Just make sure that all lines that call that method directly or by hooks, are also wrapped in premium only logic:
+To add a function which will only be available in your premium plugin version, add `__premium_only` as the suffix of the function name. Ensure that all lines that call that method directly or by hooks, are also wrapped in premium only logic:
 
 ```php
 <?php
@@ -234,7 +234,7 @@ Add logic for specified paid plan:
 ## Excluding files and folders from the free plugin version
 There are [two ways](https://freemius.com/help/documentation/wordpress-sdk/software-licensing/#excluding_files_and_folders_from_the_free_plugin_version) to exclude files from your free version. 
 
-1. Add `__premium_only` just before the file extension. For example, functions__premium_only.php will be only included in the premium plugin version. This works for all types of files, not only PHP.
+1. Add `__premium_only` just before the file extension. For example, functions__premium_only.php will be included only in the premium plugin version. This works for all types of files, not only PHP.
 2. Add `@fs_premium_only` a special meta tag to the plugin's main PHP file header. Example:
 ```php
 <?php
@@ -261,7 +261,10 @@ There are [two ways](https://freemius.com/help/documentation/wordpress-sdk/softw
 ```
 In the example plugin header above, the file `/lib/functions.php` and the directory `/premium-files/` will be removed from the free plugin version.
 
-# WordPress.org Compliance
+## Hooks: Actions and Filters
+Similar to WordPress’ filters and actions hooks, the Freemius WordPress SDK provides a [collection of filters and actions](https://freemius.com/help/documentation/wordpress-sdk/filters-actions-hooks/) that enable you to customize and extend its functionality in your WordPress plugins or themes.
+
+## WordPress.org Compliance
 Based on [WordPress.org Guidelines](https://wordpress.org/plugins/about/guidelines/) you are not allowed to submit a plugin that has premium code in it:
 > All code hosted by WordPress.org servers must be free and fully-functional. If you want to sell advanced features for a plugin (such as a "pro" version), then you must sell and serve that code from your own site, we will not host it on our servers.
 

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -4515,7 +4515,7 @@
                 /**
                  * Check if requested for manual blocking background sync.
                  */
-                if ( fs_request_has('background_sync') ) {
+                if ( fs_request_has( 'background_sync' ) ) {
                     self::require_pluggable_essentials();
                     self::wp_cookie_constants();
 

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -4495,33 +4495,31 @@
                 return;
             }
 
-            if ( $this->has_api_connectivity() ) {
-                if ( self::is_cron() ) {
-                    $this->hook_callback_to_sync_cron();
-                } else if ( $this->is_user_in_admin() ) {
-                    /**
-                     * Schedule daily data sync cron if:
-                     *
-                     *  1. User opted-in (for tracking).
-                     *  2. If skipped, but later upgraded (opted-in via upgrade).
-                     *
-                     * @author Vova Feldman (@svovaf)
-                     * @since  1.1.7.3
-                     *
-                     */
-                    if ( $this->is_registered() && $this->is_tracking_allowed() ) {
-                        $this->maybe_schedule_sync_cron();
-                    }
+            $this->hook_callback_to_sync_cron();
 
-                    /**
-                     * Check if requested for manual blocking background sync.
-                     */
-                    if ( fs_request_has( 'background_sync' ) ) {
-                        self::require_pluggable_essentials();
-                        self::wp_cookie_constants();
+            if ( $this->has_api_connectivity() && ! self::is_cron() && $this->is_user_in_admin() ) {
+                /**
+                 * Schedule daily data sync cron if:
+                 *
+                 *  1. User opted-in (for tracking).
+                 *  2. If skipped, but later upgraded (opted-in via upgrade).
+                 *
+                 * @author Vova Feldman (@svovaf)
+                 * @since  1.1.7.3
+                 *
+                 */
+                if ( $this->is_registered() && $this->is_tracking_allowed() ) {
+                    $this->maybe_schedule_sync_cron();
+                }
 
-                        $this->run_manual_sync();
-                    }
+                /**
+                 * Check if requested for manual blocking background sync.
+                 */
+                if ( fs_request_has('background_sync') ) {
+                    self::require_pluggable_essentials();
+                    self::wp_cookie_constants();
+
+                    $this->run_manual_sync();
                 }
             }
 

--- a/includes/class-fs-plugin-updater.php
+++ b/includes/class-fs-plugin-updater.php
@@ -548,12 +548,7 @@
 
             if ( ! isset( $this->_update_details ) ) {
                 // Get plugin's newest update.
-                $new_version = $this->_fs->get_update(
-                    false,
-                    fs_request_get_bool( 'force-check' ),
-                    FS_Plugin_Updater::UPDATES_CHECK_CACHE_EXPIRATION,
-                    $this->_fs->get_plugin_version()
-                );
+                $new_version = $this->_fs->get_update( false, fs_request_get_bool( 'force-check' ) );
 
                 $this->_update_details = false;
 
@@ -704,16 +699,8 @@
                 );
             }
 
-            if ( $this->_fs->is_premium() ) {
-                $latest_tag = $this->_fs->_fetch_latest_version( $this->_fs->get_id(), false );
-
-                if (
-                    isset( $latest_tag->readme ) &&
-                    isset( $latest_tag->readme->upgrade_notice ) &&
-                    ! empty( $latest_tag->readme->upgrade_notice )
-                ) {
-                    $update->upgrade_notice = $latest_tag->readme->upgrade_notice;
-                }
+            if ( $this->_fs->is_premium() && ! empty( $new_version->upgrade_notice ) ) {
+                $update->upgrade_notice = $new_version->upgrade_notice;
             }
 
             $update->{$this->_fs->get_module_type()} = $this->_fs->get_plugin_basename();

--- a/includes/customizer/class-fs-customizer-upsell-control.php
+++ b/includes/customizer/class-fs-customizer-upsell-control.php
@@ -73,7 +73,6 @@
 						'forum'              => 'Support Forum',
 						'email'              => 'Priority Email Support',
 						'phone'              => 'Phone Support',
-						'skype'              => 'Skype Support',
 						'is_success_manager' => 'Personal Success Manager',
 					);
 

--- a/includes/entities/class-fs-plugin-plan.php
+++ b/includes/entities/class-fs-plugin-plan.php
@@ -76,10 +76,6 @@
 		 */
 		public $support_phone;
 		/**
-		 * @var string Support skype username.
-		 */
-		public $support_skype;
-		/**
 		 * @var bool Is personal success manager supported with the plan.
 		 */
 		public $is_success_manager;
@@ -137,7 +133,6 @@
 		 */
 		function has_technical_support() {
 			return ( ! empty( $this->support_email ) ||
-			     ! empty( $this->support_skype ) ||
 			     ! empty( $this->support_phone ) ||
 			     ! empty( $this->is_success_manager )
 			);

--- a/includes/entities/class-fs-plugin-tag.php
+++ b/includes/entities/class-fs-plugin-tag.php
@@ -43,6 +43,10 @@
          * @var string One of the following: `pending`, `beta`, `unreleased`.
          */
         public $release_mode;
+        /**
+         * @var string
+         */
+        public $upgrade_notice;
 
 		function __construct( $tag = false ) {
 			parent::__construct( $tag );

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.12.0.2';
+	$this_sdk_version = '2.12.1';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.12.0';
+	$this_sdk_version = '2.12.0.1';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.12.0.1';
+	$this_sdk_version = '2.12.0.2';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/templates/plugin-info/features.php
+++ b/templates/plugin-info/features.php
@@ -33,7 +33,6 @@
 
 		// Add support as a feature.
 		if ( ! empty( $plan->support_email ) ||
-		     ! empty( $plan->support_skype ) ||
 		     ! empty( $plan->support_phone ) ||
 		     true === $plan->is_success_manager
 		) {


### PR DESCRIPTION
# Fixes for Update Caching, Cronjobs, and Skype Cleanup

We’re releasing version 2.12.1 of the Freemius WordPress SDK, focusing purely on bug fixes and cleanup tasks.

## Fix: Caching Issue in Update Check

We identified a regression affecting the caching mechanism of our auto-update system. In certain scenarios, especially on large multisite networks, the cache was bypassed, leading to unnecessary API calls and performance hits. This has now been fixed.

As a bonus, we did some performance improvements by reducing the amount of data fetched from our API during the update check process.

## Removal: Skype Support

With Microsoft sunsetting Skype, we’ve removed the `support_skype` property from our SDK. The property is no longer referenced in any SDK logic.

Our backend systems have already been updated so that even older versions of the SDK will no longer show it. This release removes redundant checks and references to cleanup the codebase.

## Other Notable Changes

- The cron hook system is now implemented following WordPress best practices, ensuring improved compatibility across the plugin ecosystem. Thanks to @johnbillion for the contribution.
- The SDK readme now links to our official list of supported [hooks and filters](https://freemius.com/help/documentation/wordpress-sdk/filters-actions-hooks/)
