### PR TITLE
[php82] [php-error]  Remove the skype_support dynamic property creation php error. Adds missing property from serialized object for the support_skype requirement.

### DIFF
--- a/includes/entities/class-fs-plugin-plan.php
+++ b/includes/entities/class-fs-plugin-plan.php
@@ -75,6 +75,12 @@
 		 * @var string Support phone.
 		 */
 		public $support_phone;
+        /**
+         * @var string Support skype username.
+         *
+         * @deprecated 2.12.1
+         */
+        public $support_skype = '';
 		/**
 		 * @var bool Is personal success manager supported with the plan.
 		 */

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.12.1.3';
+	$this_sdk_version = '2.12.1.4';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
- [x] Remove the dynamic property creation php error. 
- [x] Adds missing property from serialized object for the support_skype requirement.