### PR TITLE
Feature/daniele/checkout custom parameters

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -5190,9 +5190,8 @@
                 ) );
             }
 
-            if ( isset( $plugin_info['checkout'] ) && is_array( $plugin_info['checkout'] ) ) {
-                $this->_checkout_config = $this->validate_checkout_config( $plugin_info['checkout'] );
-            }
+            // Extracts, validate and save checkout-specific settings.
+            $this->_checkout_config = $this->validate_checkout_config( $plugin_info );
 
             $plugin = ( $this->_plugin instanceof FS_Plugin ) ?
                 $this->_plugin :
@@ -5344,70 +5343,65 @@
          */
         protected function validate_checkout_config($config)
         {
-            $schema = [
-                    'cart'       => [
-                            'always_show_renewals_amount'   => 'bool',
-                            'annual_discount'               => 'bool',
-                            'billing_cycle'                 => ['string', 'int'],
-                            'bundle_discount'               => 'float',
-                            'maximize_discounts'            => 'bool',
-                            'multisite_discount'            => ['bool', 'string'], // string expected to be "auto"
-                            'show_inline_currency_selector' => 'bool',
-                            'show_monthly'                  => 'bool',
-                    ],
-                    'appearance' => [
-                            'form_position'          => 'string',
-                            'is_bundle_collapsed'    => 'bool',
-                            'layout'                 => 'string',
-                            'refund_policy_position' => 'string',
-                            'show_refund_badge'      => 'bool',
-                            'show_reviews'           => 'bool',
-                            'show_upsells'           => 'bool',
-                            'title'                  => 'string',
-                    ],
-            ];
+            $schema = array(
+                // currency
+                'currency'                      => 'string',
+                'default_currency'              => 'string',
+                // cart
+                'always_show_renewals_amount'   => 'bool',
+                'annual_discount'               => 'bool',
+                'billing_cycle'                 => ['string', 'int'],
+                'bundle_discount'               => 'float',
+                'maximize_discounts'            => 'bool',
+                'multisite_discount'            => ['bool', 'string'], // string expected to be "auto"
+                'show_inline_currency_selector' => 'bool',
+                'show_monthly'                  => 'bool',
+                // appearance
+                'form_position'                 => 'string',
+                'is_bundle_collapsed'           => 'bool',
+                'layout'                        => 'string',
+                'refund_policy_position'        => 'string',
+                'show_refund_badge'             => 'bool',
+                'show_reviews'                  => 'bool',
+                'show_upsells'                  => 'bool',
+                'title'                         => 'string',
+            );
 
-            $result = [];
+            $result = array();
 
-            foreach ($schema as $section => $fields)
+            foreach ($schema as $key => $expected_type)
             {
-                if (isset($config[$section]) && is_array($config[$section]))
+                if (array_key_exists($key, $config))
                 {
-                    foreach ($fields as $key => $expected_type)
+                    $value = $config[$key];
+                    $types = is_array($expected_type) ? $expected_type : [$expected_type];
+                    $valid = false;
+
+                    foreach ($types as $type)
                     {
-                        if (array_key_exists($key, $config[$section]))
+                        switch ($type)
                         {
-                            $value = $config[$section][$key];
-                            $types = is_array($expected_type) ? $expected_type : [$expected_type];
-                            $valid = false;
-
-                            foreach ($types as $type)
-                            {
-                                switch ($type)
-                                {
-                                    case 'bool':
-                                        if (is_bool($value))
-                                            $valid = true;
-                                        break;
-                                    case 'string':
-                                        if (is_string($value))
-                                            $valid = true;
-                                        break;
-                                    case 'int':
-                                        if (is_int($value))
-                                            $valid = true;
-                                        break;
-                                    case 'float':
-                                        if (is_float($value) || is_int($value))
-                                            $valid = true;
-                                        break;
-                                }
-                            }
-
-                            if ($valid)
-                                $result[$key] = $value;
+                            case 'bool':
+                                if (is_bool($value))
+                                    $valid = true;
+                                break;
+                            case 'string':
+                                if (is_string($value))
+                                    $valid = true;
+                                break;
+                            case 'int':
+                                if (is_int($value))
+                                    $valid = true;
+                                break;
+                            case 'float':
+                                if (is_float($value) || is_int($value))
+                                    $valid = true;
+                                break;
                         }
                     }
+
+                    if ($valid)
+                        $result[$key] = $value;
                 }
             }
 

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -365,15 +365,6 @@
          */
         private $_is_bundle_license_auto_activation_enabled = false;
 
-        /**
-         * Developer-defined config overrides for checkout.
-         *
-         * @var array
-         */
-        protected $_checkout_config = [];
-
-        /**
-
         #region Uninstall Reasons IDs
 
         const REASON_NO_LONGER_NEEDED = 1;
@@ -5190,9 +5181,6 @@
                 ) );
             }
 
-            // Extracts, validate and save checkout-specific settings.
-            $this->_checkout_config = $this->validate_checkout_config( $plugin_info );
-
             $plugin = ( $this->_plugin instanceof FS_Plugin ) ?
                 $this->_plugin :
                 new FS_Plugin();
@@ -5332,88 +5320,6 @@
                     self::NAVIGATION_TABS :
                     self::NAVIGATION_MENU
             );
-        }
-
-        /**
-         * Validates and filters developer-provided checkout config.
-         *
-         * @param array $config
-         *
-         * @return array
-         */
-        protected function validate_checkout_config($config)
-        {
-            $schema = array(
-                // currency
-                'currency'                      => 'string',
-                'default_currency'              => 'string',
-                // cart
-                'always_show_renewals_amount'   => 'bool',
-                'annual_discount'               => 'bool',
-                'billing_cycle'                 => ['string', 'int'],
-                'bundle_discount'               => 'float',
-                'maximize_discounts'            => 'bool',
-                'multisite_discount'            => ['bool', 'string'], // string expected to be "auto"
-                'show_inline_currency_selector' => 'bool',
-                'show_monthly'                  => 'bool',
-                // appearance
-                'form_position'                 => 'string',
-                'is_bundle_collapsed'           => 'bool',
-                'layout'                        => 'string',
-                'refund_policy_position'        => 'string',
-                'show_refund_badge'             => 'bool',
-                'show_reviews'                  => 'bool',
-                'show_upsells'                  => 'bool',
-                'title'                         => 'string',
-            );
-
-            $result = array();
-
-            foreach ($schema as $key => $expected_type)
-            {
-                if (array_key_exists($key, $config))
-                {
-                    $value = $config[$key];
-                    $types = is_array($expected_type) ? $expected_type : [$expected_type];
-                    $valid = false;
-
-                    foreach ($types as $type)
-                    {
-                        switch ($type)
-                        {
-                            case 'bool':
-                                if (is_bool($value))
-                                    $valid = true;
-                                break;
-                            case 'string':
-                                if (is_string($value))
-                                    $valid = true;
-                                break;
-                            case 'int':
-                                if (is_int($value))
-                                    $valid = true;
-                                break;
-                            case 'float':
-                                if (is_float($value) || is_int($value))
-                                    $valid = true;
-                                break;
-                        }
-                    }
-
-                    if ($valid)
-                        $result[$key] = $value;
-                }
-            }
-
-            return $result;
-        }
-
-        /**
-         * @return array
-         */
-        public function get_checkout_config()
-        {
-            return $this->_checkout_config;
         }
 
         /**

--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -365,6 +365,15 @@
          */
         private $_is_bundle_license_auto_activation_enabled = false;
 
+        /**
+         * Developer-defined config overrides for checkout.
+         *
+         * @var array
+         */
+        protected $_checkout_config = [];
+
+        /**
+
         #region Uninstall Reasons IDs
 
         const REASON_NO_LONGER_NEEDED = 1;
@@ -5181,6 +5190,10 @@
                 ) );
             }
 
+            if ( isset( $plugin_info['checkout'] ) && is_array( $plugin_info['checkout'] ) ) {
+                $this->_checkout_config = $this->validate_checkout_config( $plugin_info['checkout'] );
+            }
+
             $plugin = ( $this->_plugin instanceof FS_Plugin ) ?
                 $this->_plugin :
                 new FS_Plugin();
@@ -5320,6 +5333,93 @@
                     self::NAVIGATION_TABS :
                     self::NAVIGATION_MENU
             );
+        }
+
+        /**
+         * Validates and filters developer-provided checkout config.
+         *
+         * @param array $config
+         *
+         * @return array
+         */
+        protected function validate_checkout_config($config)
+        {
+            $schema = [
+                    'cart'       => [
+                            'always_show_renewals_amount'   => 'bool',
+                            'annual_discount'               => 'bool',
+                            'billing_cycle'                 => ['string', 'int'],
+                            'bundle_discount'               => 'float',
+                            'maximize_discounts'            => 'bool',
+                            'multisite_discount'            => ['bool', 'string'], // string expected to be "auto"
+                            'show_inline_currency_selector' => 'bool',
+                            'show_monthly'                  => 'bool',
+                    ],
+                    'appearance' => [
+                            'form_position'          => 'string',
+                            'is_bundle_collapsed'    => 'bool',
+                            'layout'                 => 'string',
+                            'refund_policy_position' => 'string',
+                            'show_refund_badge'      => 'bool',
+                            'show_reviews'           => 'bool',
+                            'show_upsells'           => 'bool',
+                            'title'                  => 'string',
+                    ],
+            ];
+
+            $result = [];
+
+            foreach ($schema as $section => $fields)
+            {
+                if (isset($config[$section]) && is_array($config[$section]))
+                {
+                    foreach ($fields as $key => $expected_type)
+                    {
+                        if (array_key_exists($key, $config[$section]))
+                        {
+                            $value = $config[$section][$key];
+                            $types = is_array($expected_type) ? $expected_type : [$expected_type];
+                            $valid = false;
+
+                            foreach ($types as $type)
+                            {
+                                switch ($type)
+                                {
+                                    case 'bool':
+                                        if (is_bool($value))
+                                            $valid = true;
+                                        break;
+                                    case 'string':
+                                        if (is_string($value))
+                                            $valid = true;
+                                        break;
+                                    case 'int':
+                                        if (is_int($value))
+                                            $valid = true;
+                                        break;
+                                    case 'float':
+                                        if (is_float($value) || is_int($value))
+                                            $valid = true;
+                                        break;
+                                }
+                            }
+
+                            if ($valid)
+                                $result[$key] = $value;
+                        }
+                    }
+                }
+            }
+
+            return $result;
+        }
+
+        /**
+         * @return array
+         */
+        public function get_checkout_config()
+        {
+            return $this->_checkout_config;
         }
 
         /**

--- a/includes/managers/class-fs-checkout-manager.php
+++ b/includes/managers/class-fs-checkout-manager.php
@@ -12,7 +12,35 @@
 
 	class FS_Checkout_Manager {
 
-		# region Singleton
+        /**
+         * Allowlist of query parameters for checkout.
+         */
+        private $_allowed_custom_params = array(
+            // currency
+            'currency'                      => 'string',
+            'default_currency'              => 'string',
+            // cart
+            'always_show_renewals_amount'   => 'bool',
+            'annual_discount'               => 'bool',
+            'billing_cycle'                 => ['string', 'int'],
+            'bundle_discount'               => 'float',
+            'maximize_discounts'            => 'bool',
+            'multisite_discount'            => ['bool', 'string'], // string expected to be "auto"
+            'show_inline_currency_selector' => 'bool',
+            'show_monthly'                  => 'bool',
+            // appearance
+            'form_position'                 => 'string',
+            'is_bundle_collapsed'           => 'bool',
+            'layout'                        => 'string',
+            'refund_policy_position'        => 'string',
+            'show_refund_badge'             => 'bool',
+            'show_reviews'                  => 'bool',
+            'show_upsells'                  => 'bool',
+            'title'                         => 'string',
+        );
+
+
+        # region Singleton
 
 		/**
 		 * @var FS_Checkout_Manager
@@ -169,7 +197,7 @@
              *         return $params;
              *     }, 10, 5 );
              *
-             * @since 2.12.1.3
+             * @since 2.12.2.4
              *
              * @param array     $context_params The params prepared by the SDK before validation.
              * @param Freemius  $fs            The Freemius instance of the calling module.
@@ -183,7 +211,10 @@
                 $context_params
             );
 
-			return array_merge( $filtered_params, $_GET, array(
+            // Allowlist only allowed query params.
+            $filtered_params = array_intersect_key($filtered_params, $this->_allowed_custom_params);
+
+            return array_merge( $context_params, $filtered_params, $_GET, array(
 				// Current plugin version.
 				'plugin_version' => $fs->get_plugin_version(),
 				'sdk_version'    => WP_FS__SDK_VERSION,

--- a/includes/managers/class-fs-checkout-manager.php
+++ b/includes/managers/class-fs-checkout-manager.php
@@ -17,26 +17,27 @@
          */
         private $_allowed_custom_params = array(
             // currency
-            'currency'                      => 'string',
-            'default_currency'              => 'string',
+            'currency'                      => true,
+            'default_currency'              => true,
             // cart
-            'always_show_renewals_amount'   => 'bool',
-            'annual_discount'               => 'bool',
-            'billing_cycle'                 => ['string', 'int'],
-            'bundle_discount'               => 'float',
-            'maximize_discounts'            => 'bool',
-            'multisite_discount'            => ['bool', 'string'], // string expected to be "auto"
-            'show_inline_currency_selector' => 'bool',
-            'show_monthly'                  => 'bool',
+            'always_show_renewals_amount'   => true,
+            'annual_discount'               => true,
+            'billing_cycle'                 => true,
+            'billing_cycle_selector'        => true,
+            'bundle_discount'               => true,
+            'maximize_discounts'            => true,
+            'multisite_discount'            => true,
+            'show_inline_currency_selector' => true,
+            'show_monthly'                  => true,
             // appearance
-            'form_position'                 => 'string',
-            'is_bundle_collapsed'           => 'bool',
-            'layout'                        => 'string',
-            'refund_policy_position'        => 'string',
-            'show_refund_badge'             => 'bool',
-            'show_reviews'                  => 'bool',
-            'show_upsells'                  => 'bool',
-            'title'                         => 'string',
+            'form_position'                 => true,
+            'is_bundle_collapsed'           => true,
+            'layout'                        => true,
+            'refund_policy_position'        => true,
+            'show_refund_badge'             => true,
+            'show_reviews'                  => true,
+            'show_upsells'                  => true,
+            'title'                         => true,
         );
 
 
@@ -181,35 +182,7 @@
 				( $fs->is_theme() && current_user_can( 'install_themes' ) )
 			);
 
-            /**
-             * Allow developers to customize the checkout query params before final validation,
-             * so custom keys can be included and known keys can be overridden.
-             * We then validate the merged params and re-attach any unknown custom keys that
-             * validation intentionally ignores, preserving developer-provided extras while
-             * keeping core keys safe.
-             *
-             * Usage example (in a plugin/theme):
-             *
-             *     add_filter( 'fs_checkout_query_params_' . fs()->get_unique_affix(), function( $params ) {
-             *         // Add or modify query params passed to the Freemius Checkout.
-             *         $params['coupon'] = 'WELCOME10';
-             *         $params['utm_source'] = 'my-plugin';
-             *         return $params;
-             *     }, 10, 5 );
-             *
-             * @since 2.12.2.4
-             *
-             * @param array     $context_params The params prepared by the SDK before validation.
-             * @param Freemius  $fs            The Freemius instance of the calling module.
-             * @param int|mixed $plugin_id     The target plugin/add-on ID for the checkout context.
-             * @param int|mixed $plan_id       The selected plan ID (if any).
-             * @param int|mixed $licenses      The requested number of licenses (if provided).
-             */
-            $filtered_params = fs_apply_filter(
-                $fs->get_unique_affix(),
-                'checkout_query_params',
-                $context_params
-            );
+            $filtered_params = $fs->apply_filters('checkout/parameters', $context_params);
 
             // Allowlist only allowed query params.
             $filtered_params = array_intersect_key($filtered_params, $this->_allowed_custom_params);

--- a/includes/managers/class-fs-checkout-manager.php
+++ b/includes/managers/class-fs-checkout-manager.php
@@ -153,12 +153,37 @@
 				( $fs->is_theme() && current_user_can( 'install_themes' ) )
 			);
 
-            // Add developer-defined checkout overrides directly to context.
-            foreach ( $fs->get_checkout_config() as $key => $value ) {
-                $context_params[ $key ] = $value;
-            }
+            /**
+             * Allow developers to customize the checkout query params before final validation,
+             * so custom keys can be included and known keys can be overridden.
+             * We then validate the merged params and re-attach any unknown custom keys that
+             * validation intentionally ignores, preserving developer-provided extras while
+             * keeping core keys safe.
+             *
+             * Usage example (in a plugin/theme):
+             *
+             *     add_filter( 'fs_checkout_query_params_' . fs()->get_unique_affix(), function( $params ) {
+             *         // Add or modify query params passed to the Freemius Checkout.
+             *         $params['coupon'] = 'WELCOME10';
+             *         $params['utm_source'] = 'my-plugin';
+             *         return $params;
+             *     }, 10, 5 );
+             *
+             * @since 2.12.1.3
+             *
+             * @param array     $context_params The params prepared by the SDK before validation.
+             * @param Freemius  $fs            The Freemius instance of the calling module.
+             * @param int|mixed $plugin_id     The target plugin/add-on ID for the checkout context.
+             * @param int|mixed $plan_id       The selected plan ID (if any).
+             * @param int|mixed $licenses      The requested number of licenses (if provided).
+             */
+            $filtered_params = fs_apply_filter(
+                $fs->get_unique_affix(),
+                'checkout_query_params',
+                $context_params
+            );
 
-			return array_merge( $context_params, $_GET, array(
+			return array_merge( $filtered_params, $_GET, array(
 				// Current plugin version.
 				'plugin_version' => $fs->get_plugin_version(),
 				'sdk_version'    => WP_FS__SDK_VERSION,

--- a/includes/managers/class-fs-checkout-manager.php
+++ b/includes/managers/class-fs-checkout-manager.php
@@ -153,6 +153,11 @@
 				( $fs->is_theme() && current_user_can( 'install_themes' ) )
 			);
 
+            // Add developer-defined checkout overrides directly to context.
+            foreach ( $fs->get_checkout_config() as $key => $value ) {
+                $context_params[ $key ] = $value;
+            }
+
 			return array_merge( $context_params, $_GET, array(
 				// Current plugin version.
 				'plugin_version' => $fs->get_plugin_version(),

--- a/start.php
+++ b/start.php
@@ -446,6 +446,7 @@
 	 *      fs_plugin_icon_{plugin_slug}
 	 *      fs_show_trial_{plugin_slug}
 	 *      fs_is_pricing_page_visible_{plugin_slug}
+	 *      fs_checkout/parameters_{plugin_slug}
 	 *
 	 * --------------------------------------------------------
 	 *

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.12.1.3';
+	$this_sdk_version = '2.12.2.4';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.12.2.3';
+	$this_sdk_version = '2.12.1.3';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
This PR introduces support for additional checkout configuration properties in the SDK initializer.

What’s new

The following properties are now recognized during initialization:
```
// currency
'currency'                      => 'string',
'default_currency'              => 'string',
// cart
'always_show_renewals_amount'   => 'bool',
'annual_discount'               => 'bool',
'billing_cycle'                 => ['string', 'int'],
'bundle_discount'               => 'float',
'maximize_discounts'            => 'bool',
'multisite_discount'            => ['bool', 'string'], // string expected to be "auto"
'show_inline_currency_selector' => 'bool',
'show_monthly'                  => 'bool',
// appearance
'form_position'                 => 'string',
'is_bundle_collapsed'           => 'bool',
'layout'                        => 'string',
'refund_policy_position'        => 'string',
'show_refund_badge'             => 'bool',
'show_reviews'                  => 'bool',
'show_upsells'                  => 'bool',
'title'                         => 'string',
```

Behavior
	•	If these properties exist in the initialization config, they are validated and stored.
	•	When opening the checkout (both iframe and redirect modes), the provided values are automatically passed along to the checkout context.

This allows developers to customize the checkout flow appearance and cart behavior more flexibly directly from the SDK initialization.