### PR TITLE
Allow license activation for unpublished add-ons + fix undefined index notices in add-on template

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -17218,6 +17218,10 @@
             $params['is_extensions_tracking_allowed'] = FS_Permission_Manager::instance( $this )->is_extensions_tracking_allowed();
             $params['is_diagnostic_tracking_allowed'] = FS_Permission_Manager::instance( $this )->is_diagnostic_tracking_allowed();
 
+            // We want to allow people activating license on unpublished plugins if they are using a license key
+            if ( ! empty($license_key))
+                $params['show_pending'] = true;
+
             $request = array(
                 'method'  => 'POST',
                 'body'    => $params,

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.13.0';
+	$this_sdk_version = '2.13.0.1';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/templates/account/partials/addon.php
+++ b/templates/account/partials/addon.php
@@ -13,14 +13,23 @@
     $odd      = $VARS['odd'];
     $slug     = $fs->get_slug();
 
-    $fs_blog_id = $VARS['fs_blog_id'];
+    $fs_blog_id = isset( $VARS['fs_blog_id'] ) ? $VARS['fs_blog_id'] : null;
 
-    $active_plugins_directories_map = $VARS['active_plugins_directories_map'];
+    $active_plugins_directories_map = isset( $VARS['active_plugins_directories_map'] ) && is_array( $VARS['active_plugins_directories_map'] )
+        ? $VARS['active_plugins_directories_map']
+        : array();
 
-    $addon_info         = $VARS['addon_info'];
+    // Make sure addon info is always an array to avoid undefined index notices.
+    $addon_info = ( isset( $VARS['addon_info'] ) && is_array( $VARS['addon_info'] ) )
+        ? $VARS['addon_info']
+        : array();
+
     $is_addon_activated = $fs->is_addon_activated( $addon_id );
-    $is_addon_connected = $addon_info['is_connected'];
-    $is_addon_installed = $VARS['is_addon_installed'];
+
+    // If the 'is_connected' key is missing, default to false.
+    $is_addon_connected = isset( $addon_info['is_connected'] ) ? (bool) $addon_info['is_connected'] : false;
+
+    $is_addon_installed = ! empty( $VARS['is_addon_installed'] );
 
     $fs_addon = ( $is_addon_connected && $is_addon_installed ) ?
         freemius( $addon_id ) :
@@ -65,7 +74,7 @@
     $subscription           = null;
     $is_paying              = false;
     $show_upgrade           = false;
-    $is_whitelabeled        = $VARS['is_whitelabeled'];
+    $is_whitelabeled        = ! empty( $VARS['is_whitelabeled'] );
 
     if ( is_object( $fs_addon ) ) {
         $is_paying                  = $fs_addon->is_paying();
@@ -132,7 +141,7 @@
                 ( $site->trial_plan_id == $license->plan_id )
             );
 
-            $is_whitelabeled = $addon_info['is_whitelabeled'];
+            $is_whitelabeled = isset( $addon_info['is_whitelabeled'] ) ? (bool) $addon_info['is_whitelabeled'] : false;
         }
     }
 

--- a/templates/add-ons.php
+++ b/templates/add-ons.php
@@ -50,28 +50,7 @@
 
 		<?php $fs->do_action( 'addons/after_title' ) ?>
 
-        <?php
-            if (defined('WP_FS__DEV_MODE') && WP_FS__DEV_MODE && ! $fs->has_secret_key()) :
-    $integration_url = 'https://dashboard.freemius.com/#!/live/plugins/' . $fs->get_id() . '/integration/';
-    $secret_const    = 'WP_FS__' . $slug . '_SECRET_KEY';
-        ?>
-    <div class="notice notice-warning">
-        <?php echo sprintf(
-            /* translators: %s: constant name to add into wp-config.php */
-            '<p>You have enabled <code>WP_FS__DEV_MODE</code>, but no secret key is defined for this plugin. As a result, add-ons that are not publicly released yet, or that do not have publicly visible pricing, will not appear in the list below.</p>
-            <p>To configure your development environment properly, add the <code>%s</code> constant to your wp-config.php, then reload this page.
-            <a href="%s" target="_blank" rel="noopener">%s</a></p>',
-            $secret_const,
-            esc_url( $integration_url ),
-            esc_html( fs_text_inline( 'Read the integration guide', 'read-integration-guide', $slug ) )
-        ); ?>
-    </div>
-        <?php
-            endif;
-            ?>
-
-
-        <div id="poststuff">
+		<div id="poststuff">
 			<?php if ( ! $has_addons ) : ?>
 				<h3><?php echo esc_html( sprintf(
 						'%s... %s',

--- a/templates/add-ons.php
+++ b/templates/add-ons.php
@@ -50,7 +50,28 @@
 
 		<?php $fs->do_action( 'addons/after_title' ) ?>
 
-		<div id="poststuff">
+        <?php
+            if (defined('WP_FS__DEV_MODE') && WP_FS__DEV_MODE && ! $fs->has_secret_key()) :
+    $integration_url = 'https://dashboard.freemius.com/#!/live/plugins/' . $fs->get_id() . '/integration/';
+    $secret_const    = 'WP_FS__' . $slug . '_SECRET_KEY';
+        ?>
+    <div class="notice notice-warning">
+        <?php echo sprintf(
+            /* translators: %s: constant name to add into wp-config.php */
+            '<p>You have enabled <code>WP_FS__DEV_MODE</code>, but no secret key is defined for this plugin. As a result, add-ons that are not publicly released yet, or that do not have publicly visible pricing, will not appear in the list below.</p>
+            <p>To configure your development environment properly, add the <code>%s</code> constant to your wp-config.php, then reload this page.
+            <a href="%s" target="_blank" rel="noopener">%s</a></p>',
+            $secret_const,
+            esc_url( $integration_url ),
+            esc_html( fs_text_inline( 'Read the integration guide', 'read-integration-guide', $slug ) )
+        ); ?>
+    </div>
+        <?php
+            endif;
+            ?>
+
+
+        <div id="poststuff">
 			<?php if ( ! $has_addons ) : ?>
 				<h3><?php echo esc_html( sprintf(
 						'%s... %s',


### PR DESCRIPTION
The goal is to let users activate licenses even if the product is unpublished