### PR TITLE
Code Modernization: Address __wakeup() deprecation in PHP 8.5.

### DIFF
--- a/includes/entities/class-fs-user.php
+++ b/includes/entities/class-fs-user.php
@@ -54,11 +54,18 @@
 		 *
 		 * @return void
 		 */
-		function __wakeup() {
+		function __unserialize( $data ) {
 			if ( property_exists( $this, 'is_beta' ) ) {
 				// If we enter here, and we are running PHP 8.2, we already had the warning. But we sanitize data for next execution.
 				unset( $this->is_beta );
 			}
+		}
+
+		/**
+		 * Compatibility wrapper of `__unserialize` for PHP < 7.4.
+		 */
+		function __wakeup() {
+			$this->__unserialize( array() );
 		}
 
 		function get_name() {


### PR DESCRIPTION
PHP 8.5 deprecates the `__sleep()` and `__wakeup()` magic methods in favor of `__serialize()` and `__unserialize()`.

See https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods

For PHP < 7.4 compatibility, `__sleep()` and `__wakeup()` need to be kept for the time being.

This commit moves the logic of the `__wakeup()` method to `__unserialize()`, and turns the former into a wrapper. The SDK does not use `__sleep()` methods, so this is the only change required.