### PR TITLE
[payments] Add VAT to the gross amount for matching values in the accounts page in SDK

### DIFF
--- a/includes/entities/class-fs-payment.php
+++ b/includes/entities/class-fs-payment.php
@@ -132,10 +132,11 @@
          */
         function formatted_gross()
         {
+            $price = $this->gross + $this->vat;
             return (
-                ( $this->gross < 0 ? '-' : '' ) .
+                ( $price < 0 ? '-' : '' ) .
                 $this->get_symbol() .
-                number_format( abs( $this->gross ), 2, '.', ',' ) . ' ' .
+                number_format( abs( $price ), 2, '.', ',' ) . ' ' .
                 strtoupper( $this->currency )
             );
         }

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.12.2.1';
+	$this_sdk_version = '2.12.2.2';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
- [x] Add VAT to the gross amount to ensure the accounts page in SDK has matching values to the customer portal and invoice.