### PR TITLE
Remove json2

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -7098,7 +7098,6 @@
          */
         function _enqueue_connect_essentials() {
             wp_enqueue_script( 'jquery' );
-            wp_enqueue_script( 'json2' );
 
             fs_enqueue_local_script( 'postmessage', 'nojquery.ba-postmessage.js' );
             fs_enqueue_local_script( 'fs-postmessage', 'postmessage.js' );

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.13.0.2';
+	$this_sdk_version = '2.13.0.3';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/templates/checkout/frame.php
+++ b/templates/checkout/frame.php
@@ -35,7 +35,6 @@
 	}
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'json2' );
 	fs_enqueue_local_script( 'postmessage', 'nojquery.ba-postmessage.js' );
 	fs_enqueue_local_script( 'fs-postmessage', 'postmessage.js' );
 	fs_enqueue_local_script( 'fs-form', 'jquery.form.js', array( 'jquery' ) );

--- a/templates/checkout/process-redirect.php
+++ b/templates/checkout/process-redirect.php
@@ -25,7 +25,6 @@
 	$fs_checkout->verify_checkout_redirect_nonce( $fs );
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'json2' );
 	fs_enqueue_local_script( 'fs-form', 'jquery.form.js', array( 'jquery' ) );
 
 	$action = fs_request_get( '_fs_checkout_action' );

--- a/templates/contact.php
+++ b/templates/contact.php
@@ -44,7 +44,6 @@
 	}
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'json2' );
 	fs_enqueue_local_script( 'postmessage', 'nojquery.ba-postmessage.js' );
 	fs_enqueue_local_script( 'fs-postmessage', 'postmessage.js' );
 	fs_enqueue_local_style( 'fs_checkout', '/admin/common.css' );

--- a/templates/pricing.php
+++ b/templates/pricing.php
@@ -11,7 +11,6 @@
 	}
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'json2' );
 	fs_enqueue_local_script( 'postmessage', 'nojquery.ba-postmessage.js' );
 	fs_enqueue_local_script( 'fs-postmessage', 'postmessage.js' );
 	fs_enqueue_local_style( 'fs_common', '/admin/common.css' );


### PR DESCRIPTION
In WordPress 6.9, the `json2` library was no-oped as it's no longer needed by any browser. This was done as part of a larger change to remove support for old IE conditional syntax. See https://core.trac.wordpress.org/ticket/63821 and https://github.com/WordPress/wordpress-develop/commit/49d1dedd7b7efbe6f783931ebbf84e7931afb937.

This PR removes `json2` from the Freemius SDK. This should be a safe change to make because:

- If a Freemius-powered plugin depends on `json2` then it'll still get enqueued via the normal script dependency system in WordPress. The `json2` script is still registered, it's just no longer enqueued manually by the Freemius SDK.
- The `json2` library provides polyfills for `JSON.stringify()` and `JSON.parse()` by pushing its implementations onto the global `JSON` object. No browsers need this back compat, and there is nothing provided in `json2` which is not provided by `JSON` in the browser.

Fixes #840. 