### PR TITLE
[deprecation] [warning] Remove using null as an array offset is deprecated and will trigger a deprecation notice in PHP 8.5.

### DIFF
--- a/includes/managers/class-fs-contact-form-manager.php
+++ b/includes/managers/class-fs-contact-form-manager.php
@@ -77,7 +77,7 @@
 			$query_params = $this->get_query_params( $fs );
 
 			$query_params['is_standalone'] = 'true';
-			$query_params['parent_url']    = admin_url( add_query_arg( null, null ) );
+			$query_params['parent_url']    = admin_url( add_query_arg( '', '' ) );
 
 			return WP_FS__ADDRESS . '/contact/?' . http_build_query( $query_params );
 		}

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.13.0.1';
+	$this_sdk_version = '2.13.0.2';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
**REASON:** 
In PHP 8.5, using null as an array offset is deprecated and will trigger a deprecation notice. Previously, null was silently coerced to an empty string ("") when used as an array key, but this implicit behavior is being phased out to improve consistency with other parts of the language. 

**Solution**
Changing the null to empty strings fixed the issue, as the WordPress function expects strings to be used as URI/URLs. https://developer.wordpress.org/reference/functions/add_query_arg/

<img width="1628" height="1228" alt="image" src="https://github.com/user-attachments/assets/3c6b98a5-cce4-472d-92aa-cfe9f14ce86d" />
