### PR TITLE
Remove json2 enqueue (no longer available in WP 6.9)

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -7098,7 +7098,6 @@
          */
         function _enqueue_connect_essentials() {
             wp_enqueue_script( 'jquery' );
-            wp_enqueue_script( 'json2' );
 
             fs_enqueue_local_script( 'postmessage', 'nojquery.ba-postmessage.js' );
             fs_enqueue_local_script( 'fs-postmessage', 'postmessage.js' );

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.13.0.2';
+	$this_sdk_version = '2.13.0.3';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/templates/checkout/frame.php
+++ b/templates/checkout/frame.php
@@ -35,7 +35,6 @@
 	}
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'json2' );
 	fs_enqueue_local_script( 'postmessage', 'nojquery.ba-postmessage.js' );
 	fs_enqueue_local_script( 'fs-postmessage', 'postmessage.js' );
 	fs_enqueue_local_script( 'fs-form', 'jquery.form.js', array( 'jquery' ) );

--- a/templates/checkout/process-redirect.php
+++ b/templates/checkout/process-redirect.php
@@ -25,7 +25,6 @@
 	$fs_checkout->verify_checkout_redirect_nonce( $fs );
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'json2' );
 	fs_enqueue_local_script( 'fs-form', 'jquery.form.js', array( 'jquery' ) );
 
 	$action = fs_request_get( '_fs_checkout_action' );

--- a/templates/contact.php
+++ b/templates/contact.php
@@ -44,7 +44,6 @@
 	}
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'json2' );
 	fs_enqueue_local_script( 'postmessage', 'nojquery.ba-postmessage.js' );
 	fs_enqueue_local_script( 'fs-postmessage', 'postmessage.js' );
 	fs_enqueue_local_style( 'fs_checkout', '/admin/common.css' );

--- a/templates/pricing.php
+++ b/templates/pricing.php
@@ -11,7 +11,6 @@
 	}
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'json2' );
 	fs_enqueue_local_script( 'postmessage', 'nojquery.ba-postmessage.js' );
 	fs_enqueue_local_script( 'fs-postmessage', 'postmessage.js' );
 	fs_enqueue_local_style( 'fs_common', '/admin/common.css' );


### PR DESCRIPTION
Summary
This PR removes all wp_enqueue_script( 'json2' ) calls from the Freemius SDK to avoid missing dependency warnings introduced in WordPress 6.9.

Details
The json2 script was historically enqueued as a companion to jQuery to support very old browsers lacking native JSON support.
This is reflected in the codebase, where each removed json2 enqueue was immediately preceded by wp_enqueue_script( 'jquery' ).

Since WordPress 6.9 has removed the json2 handle and all supported browsers provide native JSON, this dependency is no longer needed.
The jQuery enqueues are intentionally left unchanged.

Impact
	•	No functional changes
	•	Removes admin console warnings in WordPress 6.9+
	•	Keeps the SDK aligned with modern WordPress standards