### PR TITLE
Integrate WP.org plugin check fixes from #850 into develop + version bump

### DIFF
--- a/includes/fs-essential-functions.php
+++ b/includes/fs-essential-functions.php
@@ -10,6 +10,9 @@
 	 * @license     https://www.gnu.org/licenses/gpl-3.0.html GNU General Public License Version 3
 	 * @since       1.1.5
 	 */
+    if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+    }
 
 	if ( ! function_exists( 'fs_normalize_path' ) ) {
 		if ( function_exists( 'wp_normalize_path' ) ) {

--- a/includes/managers/class-fs-debug-manager.php
+++ b/includes/managers/class-fs-debug-manager.php
@@ -6,6 +6,9 @@
      * @package   Freemius
      * @since     2.6.2
      */
+    if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+    }
 
     class FS_DebugManager {
 

--- a/templates/checkout.php
+++ b/templates/checkout.php
@@ -5,7 +5,9 @@
 	 * @license     https://www.gnu.org/licenses/gpl-3.0.html GNU General Public License Version 3
 	 * @since       2.9.0
 	 */
-
+    if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+    }
 	/**
 	 * @var array    $VARS
 	 * @var Freemius $fs


### PR DESCRIPTION
### Summary

This PR integrates the changes originally submitted by @flowdee in #850 into the `develop` branch, following our internal branching and contribution workflow.

The original contribution includes fixes addressing WordPress.org plugin check requirements.  
The commits have been cherry-picked to preserve authorship and history.

Additionally, this PR includes a version bump in `start.php` as part of our standard release preparation process.

### Credits

All functional changes were originally implemented by @flowdee in #850.  
This PR re-applies those commits to align with our branching model and adds the required version bump.

Thank you, @flowdee, for the contribution! 🙌

### Changes Included

- WordPress.org plugin check fixes (from #850)
- Version bump in `start.php`