### PR TITLE
Version 2.13.4

### DIFF
--- a/includes/managers/class-fs-checkout-manager.php
+++ b/includes/managers/class-fs-checkout-manager.php
@@ -110,6 +110,15 @@
 					// If add-on isn't activated assume the premium version isn't installed.
 					$is_premium = false;
 				}
+
+                // Override the checkout context with the add-on's purchase details so the checkout flow is initialized for the selected add-on instead of the parent product.
+				$context_params['plugin_id'] = $plugin_id;
+
+				foreach ( array( 'plan_id', 'pricing_id', 'billing_cycle', 'is_trial' ) as $param ) {
+					if ( fs_request_has( $param ) ) {
+						$context_params[ $param ] = fs_request_get( $param );
+					}
+				}
 			}
 
 			// Get site context secure params.

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.13.3.1';
+	$this_sdk_version = '2.13.4';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.13.3';
+	$this_sdk_version = '2.13.3.1';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 


### PR DESCRIPTION
## Pricing App Update, Payment History Currencies, and Other Improvements

We're releasing **SDK v2.13.4**, which includes improvements to the Pricing App, payment history section, and PHP compatibility.

### Highlights

- **Pricing App v1.4.1:** Updated the Pricing App to v1.4.1, resolving issues with thousands separators and default currency selection.
- **Payment history:** Added support for additional presentment currencies (ILS, CAD, AUD, and PLN) in the payment history section of the account page.
- **Configurable API timeout:** Added the `WP_FS__API_TIMEOUT` constant (default: 30 seconds), replacing the previously hardcoded 60-second timeout.
- **PHP compatibility improvements:** Fixed PHP warnings related to WP-CLI compatibility and a deprecation notice triggered by the contact form.
- Followed best practices when handling incoming query params.

**Note:** We unpublished the v2.13.3 release after identifying a regression in the add-on checkout flow. If you updated to v2.13.3, please update to v2.13.4, which includes the fix. Sorry for the inconvenience.