### PR TITLE
Fix fatal error on first opt-in when plugin has no paid plans

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -19869,8 +19869,10 @@
 
             // Copy plans.
             $encrypted_plans = array();
-            for ( $i = 0, $len = count( $this->_plans ); $i < $len; $i ++ ) {
-                $encrypted_plans[] = self::_encrypt_entity( $this->_plans[ $i ] );
+            if ( is_array( $this->_plans ) ) {
+                for ( $i = 0, $len = count( $this->_plans ); $i < $len; $i ++ ) {
+                    $encrypted_plans[] = self::_encrypt_entity( $this->_plans[ $i ] );
+                }
             }
 
             $plans[ $this->_slug ] = $encrypted_plans;

--- a/includes/entities/class-fs-site.php
+++ b/includes/entities/class-fs-site.php
@@ -119,7 +119,7 @@
         function __construct( $site = false ) {
             parent::__construct( $site );
 
-            if ( is_object( $site ) ) {
+            if ( is_object( $site ) && isset( $site->plan_id ) ) {
                 $this->plan_id = $site->plan_id;
             }
 


### PR DESCRIPTION
## Summary
Fixes a warning + fatal error during the first opt-in of a free-only plugin
(`'has_paid_plans' => false`).

- `FS_Site::__construct()` read `$site->plan_id` without an `isset()` guard,
  causing `Undefined property: stdClass::$plan_id` when the install object has
  no `plan_id`.
- `_store_plans()` called `count( $this->_plans )` while `_plans` was still its
  initial `false` value, causing a `TypeError` on PHP 8+.

## Changes
- `includes/entities/class-fs-site.php`: only assign `plan_id` when the property is set.
- `includes/class-freemius.php`: only iterate `_plans` in `_store_plans()` when it is an array.

Both are minimal, backward-compatible guards consistent with existing patterns
(e.g. the array checks already used in `_store_licenses()`).

## Resolved Issue 
[Fatal error on first opt-in when plugin has no paid plans (count() on bool _plans)](https://github.com/Freemius/wordpress-sdk/issues/879)

## Resolved Issue

Fixes #879


## Test plan
- [x] Fresh activation + first opt-in of a free-only plugin on PHP 8.x — no warning, no fatal.
- [x] Existing installs with plans still store/encrypt plans as before.