### PR TITLE
Fix fatal error on first opt-in for plugins without paid plans

### DIFF
--- a/includes/class-freemius.php
+++ b/includes/class-freemius.php
@@ -19869,8 +19869,10 @@
 
             // Copy plans.
             $encrypted_plans = array();
-            for ( $i = 0, $len = count( $this->_plans ); $i < $len; $i ++ ) {
-                $encrypted_plans[] = self::_encrypt_entity( $this->_plans[ $i ] );
+            if ( is_array( $this->_plans ) ) {
+                for ( $i = 0, $len = count( $this->_plans ); $i < $len; $i ++ ) {
+                    $encrypted_plans[] = self::_encrypt_entity( $this->_plans[ $i ] );
+                }
             }
 
             $plans[ $this->_slug ] = $encrypted_plans;

--- a/includes/entities/class-fs-site.php
+++ b/includes/entities/class-fs-site.php
@@ -119,7 +119,7 @@
         function __construct( $site = false ) {
             parent::__construct( $site );
 
-            if ( is_object( $site ) ) {
+            if ( is_object( $site ) && isset( $site->plan_id ) ) {
                 $this->plan_id = $site->plan_id;
             }
 


### PR DESCRIPTION
Fixes #879.

On a fresh first opt-in for a free-only plugin (`'has_paid_plans' => false`), two problems surface on PHP 8+:

- `FS_Site::__construct()` reads `$site->plan_id` even when the install object has no such property, emitting `Undefined property: stdClass::$plan_id`. Guarded the read with `isset()`, matching how the parent `FS_Entity` copies properties.
- `_store_plans()` calls `count( $this->_plans )` while `_plans` is still its default `false`, which throws `TypeError: count(): Argument #1 must be of type Countable|array, bool given` and aborts the opt-in. Wrapped the copy loop in the same `is_array( $this->_plans )` guard already used elsewhere in the class.

The SDK has no bundled test harness (it runs inside a live WordPress install), so I verified the change with a standalone script reproducing `count(false)` and the missing-property read before and after the guards.
