### PR TITLE
[addons]  Ensure cheapest addons pricing is displayed across all plans and cycles.

### DIFF
--- a/start.php
+++ b/start.php
@@ -15,7 +15,7 @@
 	 *
 	 * @var string
 	 */
-	$this_sdk_version = '2.13.4';
+	$this_sdk_version = '2.13.4.1';
 
 	#region SDK Selection Logic --------------------------------------------------------------------
 

--- a/templates/add-ons.php
+++ b/templates/add-ons.php
@@ -122,8 +122,9 @@
 
 						$open_addon = ( $open_addon || ( $open_addon_slug === $addon->slug ) );
 
-						$price     = 0;
-						$has_trial = false;
+						$price         = 0;
+                        $min_price     = 999999;
+						$has_trial     = false;
 						$has_free_plan = false;
 						$has_paid_plan = false;
 
@@ -141,11 +142,9 @@
 										continue;
 									}
 
-
 									$has_paid_plan = true;
 									$has_trial     = $has_trial || ( is_numeric( $plan->trial_period ) && ( $plan->trial_period > 0 ) );
 
-									$min_price = 999999;
 									foreach ( $plan->pricing as $pricing ) {
                                         $pricing = new FS_Pricing( $pricing );
 
@@ -163,13 +162,14 @@
 											$min_price = min( $min_price, $pricing->annual_price );
 										} else if ( $pricing->has_monthly() ) {
 											$min_price = min( $min_price, 12 * $pricing->monthly_price );
-										}
+										} else if ( $pricing->has_lifetime() ) {
+                                            $min_price = min( $min_price, $pricing->lifetime_price );
+                                        }
 									}
 
 									if ( $min_price < 999999 ) {
 										$price = $min_price;
 									}
-
 								}
 							}
 


### PR DESCRIPTION
- [x] Ensure cheapest pricing is displayed across all plans and cycles.
- [x] Including lifetime pricing in the calculation when only the lifetime pricing has been set for the product.